### PR TITLE
Fixed ArrayIndexOutOfBounds on chests loading

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/utils/islands/IslandDeserializer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/utils/islands/IslandDeserializer.java
@@ -2,11 +2,7 @@ package com.bgsoftware.superiorskyblock.utils.islands;
 
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.enums.Rating;
-import com.bgsoftware.superiorskyblock.api.island.Island;
-import com.bgsoftware.superiorskyblock.api.island.IslandChest;
-import com.bgsoftware.superiorskyblock.api.island.IslandFlag;
-import com.bgsoftware.superiorskyblock.api.island.IslandPrivilege;
-import com.bgsoftware.superiorskyblock.api.island.PlayerRole;
+import com.bgsoftware.superiorskyblock.api.island.*;
 import com.bgsoftware.superiorskyblock.api.island.warps.IslandWarp;
 import com.bgsoftware.superiorskyblock.api.island.warps.WarpCategory;
 import com.bgsoftware.superiorskyblock.api.missions.Mission;
@@ -23,49 +19,41 @@ import com.bgsoftware.superiorskyblock.utils.key.KeyMap;
 import com.bgsoftware.superiorskyblock.utils.registry.Registry;
 import com.bgsoftware.superiorskyblock.utils.threads.SyncedObject;
 import com.bgsoftware.superiorskyblock.utils.upgrades.UpgradeValue;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffectType;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public final class IslandDeserializer {
 
     static final SuperiorSkyblockPlugin plugin = SuperiorSkyblockPlugin.getPlugin();
     static final Gson gson = new GsonBuilder().create();
 
-    private IslandDeserializer(){
+    private IslandDeserializer() {
 
     }
 
     private static <T> T decode(String raw, Class<T> typeOf) throws JsonSyntaxException {
-        if(raw == null || raw.isEmpty()) throw new JsonSyntaxException("");
+        if (raw == null || raw.isEmpty()) throw new JsonSyntaxException("");
         return gson.fromJson(raw, typeOf);
     }
 
-    public static void deserializePlayers(String members, SyncedObject<? extends Collection<SuperiorPlayer>> membersSetSync){
-        try{
+    public static void deserializePlayers(String members, SyncedObject<? extends Collection<SuperiorPlayer>> membersSetSync) {
+        try {
             JsonArray playersArray = decode(members, JsonArray.class);
             membersSetSync.write(membersSet -> playersArray.forEach(uuid ->
                     membersSet.add(plugin.getPlayers().getSuperiorPlayer(UUID.fromString(uuid.getAsString())))));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializePlayers(members, membersSetSync);
         }
     }
 
-    public static void deserializePlayersWithTimes(String members, SyncedObject<? extends Collection<Pair<SuperiorPlayer, Long>>> membersSetSync){
-        try{
+    public static void deserializePlayersWithTimes(String members, SyncedObject<? extends Collection<Pair<SuperiorPlayer, Long>>> membersSetSync) {
+        try {
             JsonArray playersArray = decode(members, JsonArray.class);
             membersSetSync.write(membersSet -> playersArray.forEach(playerElement -> {
                 JsonObject playerObject = playerElement.getAsJsonObject();
@@ -73,15 +61,16 @@ public final class IslandDeserializer {
                     UUID uuid = UUID.fromString(playerObject.get("uuid").getAsString());
                     long lastTimeRecorded = playerObject.get("lastTimeRecorded").getAsLong();
                     membersSet.add(new Pair<>(plugin.getPlayers().getSuperiorPlayer(uuid), lastTimeRecorded));
-                }catch (Exception ignored){}
+                } catch (Exception ignored) {
+                }
             }));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializePlayersWithTimes(members, membersSetSync);
         }
     }
 
-    public static void deserializePermissions(String permissions, Registry<SuperiorPlayer, PlayerPermissionNode> playerPermissions, Registry<IslandPrivilege, PlayerRole> rolePermissions, Island island){
-        try{
+    public static void deserializePermissions(String permissions, Registry<SuperiorPlayer, PlayerPermissionNode> playerPermissions, Registry<IslandPrivilege, PlayerRole> rolePermissions, Island island) {
+        try {
             JsonObject globalObject = decode(permissions, JsonObject.class);
             JsonArray playersArray = globalObject.getAsJsonArray("players");
             JsonArray rolesArray = globalObject.getAsJsonArray("roles");
@@ -93,51 +82,53 @@ public final class IslandDeserializer {
                     SuperiorPlayer superiorPlayer = plugin.getPlayers().getSuperiorPlayer(uuid);
                     JsonArray permsArray = playerObject.getAsJsonArray("permissions");
                     playerPermissions.add(superiorPlayer, new PlayerPermissionNode(superiorPlayer, island, permsArray));
-                }catch (Exception ignored){}
+                } catch (Exception ignored) {
+                }
             });
 
             rolesArray.forEach(roleElement -> {
                 JsonObject roleObject = roleElement.getAsJsonObject();
                 PlayerRole playerRole = SPlayerRole.fromId(roleObject.get("id").getAsInt());
                 roleObject.getAsJsonArray("permissions").forEach(permElement -> {
-                    try{
+                    try {
                         IslandPrivilege islandPrivilege = IslandPrivilege.getByName(permElement.getAsString());
                         rolePermissions.add(islandPrivilege, playerRole);
-                    }catch (Exception ignored){}
+                    } catch (Exception ignored) {
+                    }
                 });
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializePermissions(permissions, playerPermissions, rolePermissions, island);
         }
     }
 
-    public static void deserializeUpgrades(String upgrades, Registry<String, Integer> upgradesMap){
-        try{
+    public static void deserializeUpgrades(String upgrades, Registry<String, Integer> upgradesMap) {
+        try {
             JsonArray upgradesArray = decode(upgrades, JsonArray.class);
             upgradesArray.forEach(upgradeElement -> {
                 JsonObject upgradeObject = upgradeElement.getAsJsonObject();
                 String name = upgradeObject.get("name").getAsString();
                 int level = upgradeObject.get("level").getAsInt();
-                if(plugin.getUpgrades().getUpgrade(name) != null)
+                if (plugin.getUpgrades().getUpgrade(name) != null)
                     upgradesMap.add(name, level);
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeUpgrades(upgrades, upgradesMap);
         }
     }
 
-    public static void deserializeWarps(String warps, Island island){
-        try{
+    public static void deserializeWarps(String warps, Island island) {
+        try {
             JsonArray warpsArray = decode(warps, JsonArray.class);
             warpsArray.forEach(warpElement -> {
                 JsonObject warpObject = warpElement.getAsJsonObject();
                 String name = IslandUtils.getWarpName(warpObject.get("name").getAsString());
 
-                if(name.isEmpty())
+                if (name.isEmpty())
                     return;
 
                 WarpCategory warpCategory = null;
-                if(warpObject.has("category"))
+                if (warpObject.has("category"))
                     warpCategory = island.createWarpCategory(warpObject.get("category").getAsString());
 
                 Location location = FileUtils.toLocation(warpObject.get("location").getAsString());
@@ -146,16 +137,16 @@ public final class IslandDeserializer {
                 IslandWarp islandWarp = island.createWarp(name, location, warpCategory);
                 islandWarp.setPrivateFlag(privateWarp);
 
-                if(warpObject.has("icon"))
+                if (warpObject.has("icon"))
                     islandWarp.setIcon(ItemUtils.deserializeItem(warpObject.get("icon").getAsString()));
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeWarps(warps, island);
         }
     }
 
-    public static void deserializeBlockCounts(String blocks, Island island){
-        try{
+    public static void deserializeBlockCounts(String blocks, Island island) {
+        try {
             JsonArray blockCountsArray = decode(blocks, JsonArray.class);
             blockCountsArray.forEach(blockCountElement -> {
                 JsonObject blockCountObject = blockCountElement.getAsJsonObject();
@@ -163,13 +154,13 @@ public final class IslandDeserializer {
                 BigInteger amount = new BigInteger(blockCountObject.get("amount").getAsString());
                 island.handleBlockPlace(blockKey, amount, false);
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeBlockCounts(blocks, island);
         }
     }
 
-    public static void deserializeBlockLimits(String blocks, SyncedObject<KeyMap<UpgradeValue<Integer>>> blockLimits){
-        try{
+    public static void deserializeBlockLimits(String blocks, SyncedObject<KeyMap<UpgradeValue<Integer>>> blockLimits) {
+        try {
             JsonArray blockLimitsArray = decode(blocks, JsonArray.class);
             blockLimits.write(_blockLimits -> blockLimitsArray.forEach(blockLimitElement -> {
                 JsonObject blockLimitObject = blockLimitElement.getAsJsonObject();
@@ -177,13 +168,13 @@ public final class IslandDeserializer {
                 int limit = blockLimitObject.get("limit").getAsInt();
                 _blockLimits.put(blockKey, new UpgradeValue<>(limit, i -> i < 0));
             }));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeBlockLimits(blocks, blockLimits);
         }
     }
 
-    public static void deserializeEntityLimits(String entities, SyncedObject<KeyMap<UpgradeValue<Integer>>> entityLimits){
-        try{
+    public static void deserializeEntityLimits(String entities, SyncedObject<KeyMap<UpgradeValue<Integer>>> entityLimits) {
+        try {
             JsonArray entityLimitsArray = decode(entities, JsonArray.class);
             entityLimits.write(_entityLimits -> entityLimitsArray.forEach(entityLimitElement -> {
                 JsonObject entityLimitObject = entityLimitElement.getAsJsonObject();
@@ -191,29 +182,30 @@ public final class IslandDeserializer {
                 int limit = entityLimitObject.get("limit").getAsInt();
                 _entityLimits.put(entity, new UpgradeValue<>(limit, i -> i < 0));
             }));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeEntityLimits(entities, entityLimits);
         }
     }
 
-    public static void deserializeRatings(String ratings, Registry<UUID, Rating> ratingsMap){
-        try{
+    public static void deserializeRatings(String ratings, Registry<UUID, Rating> ratingsMap) {
+        try {
             JsonArray ratingsArray = decode(ratings, JsonArray.class);
             ratingsArray.forEach(ratingElement -> {
                 JsonObject ratingObject = ratingElement.getAsJsonObject();
-                try{
+                try {
                     UUID uuid = UUID.fromString(ratingObject.get("player").getAsString());
                     Rating rating = Rating.valueOf(ratingObject.get("rating").getAsInt());
                     ratingsMap.add(uuid, rating);
-                }catch (Exception ignored){}
+                } catch (Exception ignored) {
+                }
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeRatings(ratings, ratingsMap);
         }
     }
 
-    public static void deserializeMissions(String missions, Registry<Mission<?>, Integer> completedMissions){
-        try{
+    public static void deserializeMissions(String missions, Registry<Mission<?>, Integer> completedMissions) {
+        try {
             JsonArray missionsArray = decode(missions, JsonArray.class);
             missionsArray.forEach(missionElement -> {
                 JsonObject missionObject = missionElement.getAsJsonObject();
@@ -223,36 +215,37 @@ public final class IslandDeserializer {
 
                 Mission<?> mission = plugin.getMissions().getMission(name);
 
-                if(mission != null)
+                if (mission != null)
                     completedMissions.add(mission, finishCount);
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeMissions(missions, completedMissions);
         }
     }
 
-    public static void deserializeIslandFlags(String settings, Registry<IslandFlag, Byte> islandFlags){
-        try{
+    public static void deserializeIslandFlags(String settings, Registry<IslandFlag, Byte> islandFlags) {
+        try {
             JsonArray islandFlagsArray = decode(settings, JsonArray.class);
             islandFlagsArray.forEach(islandFlagElement -> {
                 JsonObject islandFlagObject = islandFlagElement.getAsJsonObject();
-                try{
+                try {
                     IslandFlag islandFlag = IslandFlag.getByName(islandFlagObject.get("name").getAsString());
                     byte status = islandFlagObject.get("status").getAsByte();
                     islandFlags.add(islandFlag, status);
-                }catch (Exception ignored){}
+                } catch (Exception ignored) {
+                }
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeIslandFlags(settings, islandFlags);
         }
     }
 
-    public static void deserializeGenerators(String generator, SyncedObject<KeyMap<UpgradeValue<Integer>>>[] cobbleGenerator){
-        try{
+    public static void deserializeGenerators(String generator, SyncedObject<KeyMap<UpgradeValue<Integer>>>[] cobbleGenerator) {
+        try {
             JsonArray generatorWorldsArray = decode(generator, JsonArray.class);
             generatorWorldsArray.forEach(generatorWorldElement -> {
                 JsonObject generatorWorldObject = generatorWorldElement.getAsJsonObject();
-                try{
+                try {
                     int i = World.Environment.valueOf(generatorWorldObject.get("env").getAsString()).ordinal();
                     generatorWorldObject.getAsJsonArray("rates").forEach(generatorElement -> {
                         JsonObject generatorObject = generatorElement.getAsJsonObject();
@@ -261,46 +254,48 @@ public final class IslandDeserializer {
                         (cobbleGenerator[i] = SyncedObject.of(new KeyMap<>())).write(_cobbleGenerator ->
                                 _cobbleGenerator.put(blockKey, new UpgradeValue<>(rate, n -> n < 0)));
                     });
-                }catch (Exception ignored){}
+                } catch (Exception ignored) {
+                }
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeGenerators(generator, cobbleGenerator);
         }
     }
 
-    public static void deserializeLocations(String locationParam, SyncedObject<Location[]> locations){
-        try{
+    public static void deserializeLocations(String locationParam, SyncedObject<Location[]> locations) {
+        try {
             JsonArray locationsArray = decode(locationParam, JsonArray.class);
             locations.write(_locations -> locationsArray.forEach(locationElement -> {
                 JsonObject locationObject = locationElement.getAsJsonObject();
-                try{
+                try {
                     int i = World.Environment.valueOf(locationObject.get("env").getAsString()).ordinal();
                     _locations[i] = FileUtils.toLocation(locationObject.get("location").getAsString());
-                }catch (Exception ignored){}
+                } catch (Exception ignored) {
+                }
             }));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeLocations(locationParam, locations);
         }
     }
 
-    public static void deserializeEffects(String effects, SyncedObject<Map<PotionEffectType, UpgradeValue<Integer>>> islandEffects){
-        try{
+    public static void deserializeEffects(String effects, SyncedObject<Map<PotionEffectType, UpgradeValue<Integer>>> islandEffects) {
+        try {
             JsonArray effectsArray = decode(effects, JsonArray.class);
             islandEffects.write(_islandEffects -> effectsArray.forEach(effectElement -> {
                 JsonObject effectObject = effectElement.getAsJsonObject();
                 PotionEffectType potionEffectType = PotionEffectType.getByName(effectObject.get("type").getAsString());
-                if(potionEffectType != null){
+                if (potionEffectType != null) {
                     int level = effectObject.get("level").getAsInt();
                     _islandEffects.put(potionEffectType, new UpgradeValue<>(level, i -> i < 0));
                 }
             }));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeEffects(effects, islandEffects);
         }
     }
 
-    public static void deserializeIslandChest(Island island, String islandChest, SyncedObject<IslandChest[]> islandChestSync){
-        try{
+    public static void deserializeIslandChest(Island island, String islandChest, SyncedObject<IslandChest[]> islandChestSync) {
+        try {
             JsonArray islandChestsArray = decode(islandChest, JsonArray.class);
             List<IslandChest> islandChestList = new ArrayList<>();
 
@@ -308,33 +303,38 @@ public final class IslandDeserializer {
                 JsonObject islandChestObject = islandChestElement.getAsJsonObject();
                 int i = islandChestObject.get("index").getAsInt();
                 String contents = islandChestObject.get("contents").getAsString();
-                islandChestList.add(i, SIslandChest.createChest(island, i, ItemUtils.deserialize(contents)));
+
+                if (i >= islandChestList.size()) {
+                    islandChestList.add(SIslandChest.createChest(island, i, ItemUtils.deserialize(contents)));
+                } else
+                    islandChestList.add(i, SIslandChest.createChest(island, i, ItemUtils.deserialize(contents)));
+
             });
 
             islandChestSync.set(islandChestList.toArray(new IslandChest[0]));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeIslandChest(island, islandChest, islandChestSync);
         }
     }
 
-    public static void deserializeRoleLimits(String roles, SyncedObject<Map<PlayerRole, UpgradeValue<Integer>>> roleLimits){
-        try{
+    public static void deserializeRoleLimits(String roles, SyncedObject<Map<PlayerRole, UpgradeValue<Integer>>> roleLimits) {
+        try {
             JsonArray roleLimitsArray = decode(roles, JsonArray.class);
             roleLimits.write(_roleLimits -> roleLimitsArray.forEach(roleElement -> {
                 JsonObject roleObject = roleElement.getAsJsonObject();
                 PlayerRole playerRole = SPlayerRole.fromId(roleObject.get("id").getAsInt());
-                if(playerRole != null){
+                if (playerRole != null) {
                     int limit = roleObject.get("limit").getAsInt();
                     _roleLimits.put(playerRole, new UpgradeValue<>(limit, i -> i < 0));
                 }
             }));
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeRoleLimits(roles, roleLimits);
         }
     }
 
-    public static void deserializeWarpCategories(String warpCategories, Island island){
-        try{
+    public static void deserializeWarpCategories(String warpCategories, Island island) {
+        try {
             JsonArray warpCategoriesArray = decode(warpCategories, JsonArray.class);
             warpCategoriesArray.forEach(warpCategoryElement -> {
                 JsonObject warpCategoryObject = warpCategoryElement.getAsJsonObject();
@@ -342,8 +342,8 @@ public final class IslandDeserializer {
 
                 WarpCategory warpCategory = island.getWarpCategory(name);
 
-                if(warpCategory != null){
-                    if(warpCategory.getWarps().isEmpty()) {
+                if (warpCategory != null) {
+                    if (warpCategory.getWarps().isEmpty()) {
                         island.deleteCategory(warpCategory);
                         return;
                     }
@@ -352,12 +352,12 @@ public final class IslandDeserializer {
                     warpCategory.setSlot(slot);
 
                     ItemStack icon = ItemUtils.deserializeItem(warpCategoryObject.get("icon").getAsString());
-                    if(icon != null)
+                    if (icon != null)
                         warpCategory.setIcon(icon);
                 }
 
             });
-        }catch (JsonSyntaxException ex){
+        } catch (JsonSyntaxException ex) {
             IslandDeserializer_Old.deserializeWarpCategories(warpCategories, island);
         }
     }


### PR DESCRIPTION
People were getting
`[13:07:48 WARN]: java.lang.IndexOutOfBoundsException: Index: 2, Size: 1
[13:07:48 WARN]:        at java.base/java.util.ArrayList.rangeCheckForAdd(ArrayList.java:788)
[13:07:48 WARN]:        at java.base/java.util.ArrayList.add(ArrayList.java:513)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.utils.islands.IslandDeserializer.lambda$deserializeIslandChest$28(IslandDeserializer.java:311)
[13:07:48 WARN]:        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.utils.islands.IslandDeserializer.deserializeIslandChest(IslandDeserializer.java:307)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.island.SIsland.<init>(SIsland.java:221)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.handlers.FactoriesHandler.createIsland(FactoriesHandler.java:35)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.handlers.GridHandler.createIsland(GridHandler.java:106)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.handlers.DataHandler.lambda$loadDatabase$2(DataHandler.java:219)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.utils.database.SQLHelper.executeQuery(SQLHelper.java:142)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.handlers.DataHandler.loadDatabase(DataHandler.java:214)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.handlers.DataHandler.loadDataWithException(DataHandler.java:65)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin.reloadPlugin(SuperiorSkyblockPlugin.java:394)
[13:07:48 WARN]:        at com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin.onEnable(SuperiorSkyblockPlugin.java:174)
[13:07:48 WARN]:        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:263)
[13:07:48 WARN]:        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:380)
[13:07:48 WARN]:        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:483)
[13:07:48 WARN]:        at org.bukkit.craftbukkit.v1_16_R3.CraftServer.enablePlugin(CraftServer.java:501)
[13:07:48 WARN]:        at org.bukkit.craftbukkit.v1_16_R3.CraftServer.enablePlugins(CraftServer.java:415)
[13:07:48 WARN]:        at net.minecraft.server.v1_16_R3.MinecraftServer.loadWorld(MinecraftServer.java:582)
[13:07:48 WARN]:        at net.minecraft.server.v1_16_R3.DedicatedServer.init(DedicatedServer.java:302)
[13:07:48 WARN]:        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1065)
[13:07:48 WARN]:        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:291)
[13:07:48 WARN]:        at java.base/java.lang.Thread.run(Thread.java:834`

So I fixed by checking if the index is correct