### PR TITLE
Add scale and rounding to SIslandBank#setBalance(BigDecimal, boolean)

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
@@ -49,7 +49,7 @@ public final class SIslandBank implements IslandBank {
 
     @Override
     public BigDecimal getBalance() {
-        return balance.get();
+        return balance.get().setScale(2, RoundingMode.HALF_DOWN);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
@@ -26,6 +26,7 @@ import org.bukkit.entity.Player;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -263,7 +264,7 @@ public final class SIslandBank implements IslandBank {
     }
 
     private void setBalance(BigDecimal balance, boolean save){
-        this.balance.set(balance);
+        this.balance.set(balance.setScale(2, RoundingMode.HALF_DOWN));
 
         if(save){
             Query.ISLAND_SET_BANK.getStatementHolder((SIslandDataHandler) island.getDataHandler())

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
@@ -264,7 +264,7 @@ public final class SIslandBank implements IslandBank {
     }
 
     private void setBalance(BigDecimal balance, boolean save){
-        this.balance.set(balance.setScale(2, RoundingMode.HALF_DOWN));
+        this.balance.set(balance);
 
         if(save){
             Query.ISLAND_SET_BANK.getStatementHolder((SIslandDataHandler) island.getDataHandler())


### PR DESCRIPTION
IslandBanks have currently no precision set, that allows them to be more precise than will ever be necessary, when i was browsing SuperiorSkyblock database i noticed that there's a islandBank column with over 5k decimals, (see attached image). We can save up space by adding a 2 digit precision and round the decimals down.
![image](https://user-images.githubusercontent.com/37771960/126669320-316ac320-9059-44bd-9c0a-2ef95dd3ed61.png)
