### PR TITLE
Add rouding to SIslandBank

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/bank/SIslandBank.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Player;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +51,7 @@ public final class SIslandBank implements IslandBank {
 
     @Override
     public BigDecimal getBalance() {
-        return balance.get();
+        return balance.get().setScale(2, RoundingMode.HALF_DOWN);
     }
 
     @Override


### PR DESCRIPTION
Currently, there is no precision limit, and that fills the database with useless decimals. I added 2 decimal precision and [HALF_DOWN](https://docs.oracle.com/javase/7/docs/api/java/math/RoundingMode.html#HALF_DOWN) rounding mode to SIslandBank#getBalance. See attached image, row with over 5000 decimals. 

![image](https://user-images.githubusercontent.com/37771960/126954261-8ad58d28-2a2f-463c-87af-fc1477738d76.png)