### PR TITLE
Fix world must be an island exception

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/world/WorldInfo.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/world/WorldInfo.java
@@ -23,7 +23,6 @@ public interface WorldInfo {
      */
     static WorldInfo of(World world) {
         Preconditions.checkNotNull(world, "world parameter cannot be null");
-        Preconditions.checkArgument(SuperiorSkyblockAPI.getGrid().isIslandsWorld(world), "World must be an islands world.");
         return of(world.getName(), world.getEnvironment());
     }
 


### PR DESCRIPTION
Fixes #1415, AFAIK we don't need to check if the world is an island there, so far I've run into no issues.