### PR TITLE
Fix NullPointerException on login

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -1417,10 +1417,7 @@ public class SIsland implements Island {
     }
 
     @Override
-    public void replacePlayers(SuperiorPlayer originalPlayer, SuperiorPlayer newPlayer) {
-        Preconditions.checkNotNull(originalPlayer, "originalPlayer parameter cannot be null.");
-        Preconditions.checkNotNull(newPlayer, "newPlayer parameter cannot be null.");
-
+    public void replacePlayers(@NotNull SuperiorPlayer originalPlayer, @NotNull SuperiorPlayer newPlayer) {
         if (owner == originalPlayer) {
             owner = newPlayer;
             IslandsDatabaseBridge.saveIslandLeader(this);


### PR DESCRIPTION
Fixed error: 
Could not pass event PlayerLoginEvent to SuperiorSkyblock2 v2022.9-b954 java.lang.NullPointerException: newPlayer parameter cannot be null.
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:907) ~[guava-31.0.1-jre.jar:?]
        at com.bgsoftware.superiorskyblock.island.SIsland.replacePlayers(SIsland.java:1470) ~[SuperiorSkyblock2-2022.9-b954.jar:?]
        at com.bgsoftware.superiorskyblock.player.PlayersManagerImpl.replacePlayers(PlayersManagerImpl.java:164) ~[SuperiorSkyblock2-2022.9-b954.jar:?]
        at com.bgsoftware.superiorskyblock.listener.PlayersListener.lambda$onPlayerLogin$1(PlayersListener.java:101) ~[SuperiorSkyblock2-2022.9-b954.jar:?]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1092) ~[?:?]
        at com.bgsoftware.superiorskyblock.listener.PlayersListener.onPlayerLogin(PlayersListener.java:100) ~[SuperiorSkyblock2-2022.9-b954.jar:?]
        at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:37) ~[purpur-api-1.19-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:76) ~[purpur-api-1.19-R0.1-SNAPSHOT.jar:git-Purpur-1735]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[purpur-api-1.19-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:678) ~[purpur-api-1.19-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.players.PlayerList.canPlayerLogin(PlayerList.java:784) ~[purpur-1.19.jar:git-Purpur-1735]
        at net.minecraft.server.network.ServerLoginPacketListenerImpl.handleAcceptedLogin(ServerLoginPacketListenerImpl.java:182) ~[?:?]
        at net.minecraft.server.network.ServerLoginPacketListenerImpl.tick(ServerLoginPacketListenerImpl.java:93) ~[?:?]
        at net.minecraft.network.Connection.tick(Connection.java:568) ~[?:?]
        at net.minecraft.server.network.ServerConnectionListener.tick(ServerConnectionListener.java:232) ~[?:?]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1610) ~[purpur-1.19.jar:git-Purpur-1735]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:485) ~[purpur-1.19.jar:git-Purpur-1735]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1442) ~[purpur-1.19.jar:git-Purpur-1735]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1209) ~[purpur-1.19.jar:git-Purpur-1735]
        at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:308) ~[purpur-1.19.jar:git-Purpur-1735]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]