### PR TITLE
Add placeholder to return schematic name

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/service/placeholders/PlaceholdersServiceImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/service/placeholders/PlaceholdersServiceImpl.java
@@ -100,6 +100,7 @@ public class PlaceholdersServiceImpl implements PlaceholdersService, IService {
                             island.getCenter(plugin.getSettings().getWorlds().getDefaultWorldDimension()).getBlockZ() + "")
                     .put("world", (island, superiorPlayer) ->
                             island.getCenter(plugin.getSettings().getWorlds().getDefaultWorldDimension()).getWorld().getName())
+                    .put("schematic", (island, superiorPlayer) -> island.getSchematicName())
                     .put("team_size", (island, superiorPlayer) -> island.getIslandMembers(true).size() + "")
                     .put("team_size_online", (island, superiorPlayer) ->
                             island.getIslandMembers(true).stream().filter(SuperiorPlayer::isShownAsOnline).count() + "")


### PR DESCRIPTION
Add `superior_island_schematic` to return the schematic name for the players island, stored under `island_type` in the database.

Sorry if I did this wrong, but I noticed there's no placeholder that simply returns the name of the schematic, and not the island name already available.