### PR TITLE
Added missing placeholders and reorganized the placeholder file for better readability

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/service/placeholders/PlaceholdersServiceImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/service/placeholders/PlaceholdersServiceImpl.java
@@ -417,6 +417,12 @@ public class PlaceholdersServiceImpl implements PlaceholdersService, IService {
                     .put("z", (island, superiorPlayer) ->
                             island.getCenterPosition().getZ() + "")
                     // Global Placeholders
+                    .put("total_count", (island, superiorPlayer) ->
+                            Formatters.NUMBER_FORMATTER.format(plugin.getGrid().getIslands().size()))
+                    .put("total_count_format", (island, superiorPlayer) ->
+                            Formatters.FANCY_NUMBER_FORMATTER.format(plugin.getGrid().getIslands().size(), superiorPlayer.getUserLocale()))
+                    .put("total_count_raw", (island, superiorPlayer) ->
+                            plugin.getGrid().getIslands().size() + "")
                     .put("total_level", (island, superiorPlayer) ->
                             Formatters.NUMBER_FORMATTER.format(plugin.getGrid().getTotalLevel()))
                     .put("total_level_format", (island, superiorPlayer) ->


### PR DESCRIPTION
The file content has changed quite a bit, so I checked all the placeholders to make sure nothing got messed up. If you want I can also prepare an updated list of placeholders for the wiki, you just have to tell me how to save it so you don't have to format everything yourself 😅

I've added placeholders from this [Discussion](https://github.com/BG-Software-LLC/SuperiorSkyblock2/discussions/2602), so once the changes are merged, it can be closed.

# Changelog #
*All placeholders below are for the island (superior_island_placeholder...)*

Added placeholders:
```
- bank_int
- bank_limit_int, bank_limit_raw
- bank_last_interest
- bans_count
- bans_list
- block_level_<block>
- block_total_level_<block>
- block_total_worth_<block>
- block_worth_<block>
- bonus_level, bonus_level_format, bonus_level_int, bonus_level_raw
- bonus_worth, bonus_worth_format, bonus_worth_int, bonus_worth_raw
- chest_size
- coop_list
- coop_size
- data_<path>
- description
- effect_<effect>
- generator_amount_<world>_<block>
- generator_percentage_<world>_<block>
- home, home_x, home_y, home_z
- is_visitor
- last_time_updated
- normal_unlocked
- players_count
- players_list
- raw_bank_limit, raw_bank_limit_format, raw_bank_limit_int, raw_bank_limit_raw
- raw_coop_limit
- raw_crops_multiplier
- raw_drops_multiplier
- raw_level, raw_level_format, raw_level_int, raw_level_raw
- raw_radius
- raw_spawners_multiplier
- raw_team_limit
- raw_warps_limit
- raw_worth_int, raw_worth_raw
- role_count_<role>
- role_limit_<role>
- team_list
- total_count
- total_count_format
- total_count_raw
- total_level_int
- total_level_raw
- total_worth_int
- total_worth_raw
- unique_visitors_count
- unique_visitors_list
- visitors_list
- visitors_location, visitors_location_x, visitors_location_y, visitors_location_z
```

Renamed placeholders:
```
- count_<block> -> block_count_<block>
- x -> center_x
- y -> center_y
- z -> center_z
```

Removed placeholders:
```
- hoppers_limit (there is a block_limit_<block> placeholder, so this one was unnecessary)
```