### PR TITLE
Changed clear inventory on disband and join options

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -237,12 +237,6 @@ public interface SettingsManager {
     String getStackedBlocksProvider();
 
     /**
-     * Whether inventory of island members should be cleared when their island is disbanded or not.
-     * Config-path: disband-inventory-clear
-     */
-    boolean isDisbandInventoryClear();
-
-    /**
      * All settings related to island-names.
      * Config path: island-names
      */
@@ -261,10 +255,28 @@ public interface SettingsManager {
     boolean isTeleportOnKick();
 
     /**
-     * Whether to clear players' inventories when they join a new island or not.
-     * Config-path: clear-on-join
+     * Whether to clear members Ender Chest when their island is disbanded or not.
+     * Config-path: clear-ender-chest-on-disband
      */
-    boolean isClearOnJoin();
+    boolean isClearEnderChestOnDisband();
+
+    /**
+     * Whether to clear players Ender Chest when they join a new island or not.
+     * Config-path: clear-ender-chest-on-join
+     */
+    boolean isClearEnderChestOnJoin();
+
+    /**
+     * Whether to clear players inventory when their island is disbanded or not.
+     * Config-path: clear-inventory-on-disband
+     */
+    boolean isClearInventoryOnDisband();
+
+    /**
+     * Whether to clear players inventory when they join a new island or not.
+     * Config-path: clear-inventory-on-join
+     */
+    boolean isClearInventoryOnJoin();
 
     /**
      * Whether players can rate their own island or not.

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_12_R1/NMSPlayersImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_12_R1/NMSPlayersImpl.java
@@ -41,11 +41,26 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -58,7 +73,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_16_R3/NMSPlayersImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_16_R3/NMSPlayersImpl.java
@@ -43,12 +43,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -62,7 +77,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_17/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_17/NMSPlayersImpl.java
+++ b/NMS/v1_17/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_17/NMSPlayersImpl.java
@@ -41,12 +41,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -63,7 +78,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_18/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_18/NMSPlayersImpl.java
+++ b/NMS/v1_18/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_18/NMSPlayersImpl.java
@@ -41,12 +41,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -63,7 +78,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSPlayersImpl.java
+++ b/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSPlayersImpl.java
@@ -41,12 +41,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -63,7 +78,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSPlayersImpl.java
+++ b/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSPlayersImpl.java
@@ -42,12 +42,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -64,7 +79,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSPlayersImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSPlayersImpl.java
@@ -42,12 +42,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -64,7 +79,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSPlayersImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSPlayersImpl.java
@@ -42,12 +42,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -64,7 +79,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSPlayersImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSPlayersImpl.java
@@ -42,12 +42,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -64,7 +79,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSPlayersImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSPlayersImpl.java
@@ -45,12 +45,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -67,7 +82,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSPlayersImpl.java
+++ b/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSPlayersImpl.java
@@ -45,12 +45,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -67,7 +82,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_21_6/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_6/NMSPlayersImpl.java
+++ b/NMS/v1_21_6/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_6/NMSPlayersImpl.java
@@ -45,12 +45,27 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
             assert player != null;
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -67,7 +82,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_8_R3/NMSPlayersImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_8_R3/NMSPlayersImpl.java
@@ -41,11 +41,26 @@ public class NMSPlayersImpl implements NMSPlayers {
     }
 
     @Override
+    public void clearEnderChest(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, false, true);
+    }
+
+    @Override
     public void clearInventory(OfflinePlayer offlinePlayer) {
+        clearInventoryInternal(offlinePlayer, true, false);
+    }
+
+    public void clearInventoryInternal(OfflinePlayer offlinePlayer, boolean inventory, boolean enderchest) {
         if (offlinePlayer.isOnline() || offlinePlayer instanceof Player) {
             Player player = offlinePlayer instanceof Player ? (Player) offlinePlayer : offlinePlayer.getPlayer();
-            player.getInventory().clear();
-            player.getEnderChest().clear();
+
+            if (inventory) {
+                player.getInventory().clear();
+            }
+            if (enderchest) {
+                player.getEnderChest().clear();
+            }
+
             return;
         }
 
@@ -58,7 +73,12 @@ public class NMSPlayersImpl implements NMSPlayers {
 
         targetPlayer.loadData();
 
-        clearInventory(targetPlayer);
+        if (inventory) {
+            clearInventory(targetPlayer);
+        }
+        if (enderchest) {
+            clearEnderChest(targetPlayer);
+        }
 
         //Setting the entity to the spawn location
         Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAdd.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAdd.java
@@ -91,7 +91,9 @@ public class CmdAdminAdd implements IAdminIslandCommand {
 
         if (plugin.getSettings().isTeleportOnJoin() && targetPlayer.isOnline())
             targetPlayer.teleport(island);
-        if (plugin.getSettings().isClearOnJoin())
+        if (plugin.getSettings().isClearEnderChestOnJoin())
+            plugin.getNMSPlayers().clearEnderChest(targetPlayer.asOfflinePlayer());
+        if (plugin.getSettings().isClearInventoryOnJoin())
             plugin.getNMSPlayers().clearInventory(targetPlayer.asOfflinePlayer());
     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAccept.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAccept.java
@@ -101,7 +101,9 @@ public class CmdAccept implements ISuperiorCommand {
 
         if (plugin.getSettings().isTeleportOnJoin())
             superiorPlayer.teleport(island);
-        if (plugin.getSettings().isClearOnJoin())
+        if (plugin.getSettings().isClearEnderChestOnJoin())
+            plugin.getNMSPlayers().clearEnderChest(superiorPlayer.asPlayer());
+        if (plugin.getSettings().isClearInventoryOnJoin())
             plugin.getNMSPlayers().clearInventory(superiorPlayer.asPlayer());
     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -141,7 +141,6 @@ public class SettingsContainer {
     public final boolean leaveConfirm;
     public final String spawnersProvider;
     public final String stackedBlocksProvider;
-    public final boolean disbandInventoryClear;
     public final boolean islandNamesRequiredForCreation;
     public final int islandNamesMaxLength;
     public final int islandNamesMinLength;
@@ -151,7 +150,10 @@ public class SettingsContainer {
     public final boolean islandNamesPreventPlayerNames;
     public final boolean teleportOnJoin;
     public final boolean teleportOnKick;
-    public final boolean clearOnJoin;
+    public final boolean clearEnderChestOnDisband;
+    public final boolean clearEnderChestOnJoin;
+    public final boolean clearInventoryOnDisband;
+    public final boolean clearInventoryOnJoin;
     public final boolean rateOwnIsland;
     public final boolean changeIslandRating;
     public final List<String> defaultSettings;
@@ -380,7 +382,6 @@ public class SettingsContainer {
         leaveConfirm = config.getBoolean("leave-confirm");
         spawnersProvider = config.getString("spawners-provider", "AUTO");
         stackedBlocksProvider = config.getString("stacked-blocks-provider", "AUTO");
-        disbandInventoryClear = config.getBoolean("disband-inventory-clear", true);
         islandNamesRequiredForCreation = config.getBoolean("island-names.required-for-creation", true);
         islandNamesMaxLength = config.getInt("island-names.max-length", 16);
         islandNamesMinLength = config.getInt("island-names.min-length", 3);
@@ -392,7 +393,10 @@ public class SettingsContainer {
         islandNamesPreventPlayerNames = config.getBoolean("island-names.prevent-player-names", true);
         teleportOnJoin = config.getBoolean("teleport-on-join", false);
         teleportOnKick = config.getBoolean("teleport-on-kick", false);
-        clearOnJoin = config.getBoolean("clear-on-join", false);
+        clearEnderChestOnDisband = config.getBoolean("clear-ender-chest-on-disband", true);
+        clearEnderChestOnJoin = config.getBoolean("clear-ender-chest-on-join", false);
+        clearInventoryOnDisband = config.getBoolean("clear-inventory-on-disband", true);
+        clearInventoryOnJoin = config.getBoolean("clear-inventory-on-join", true);
         rateOwnIsland = config.getBoolean("rate-own-island", false);
         changeIslandRating = config.getBoolean("change-island-rating", true);
         defaultSettings = Collections.unmodifiableList(config.getStringList("default-settings")

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -262,11 +262,6 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     @Override
-    public boolean isDisbandInventoryClear() {
-        return this.global.isDisbandInventoryClear();
-    }
-
-    @Override
     public IslandNames getIslandNames() {
         return this.islandNames;
     }
@@ -282,8 +277,23 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     @Override
-    public boolean isClearOnJoin() {
-        return this.global.isClearOnJoin();
+    public boolean isClearEnderChestOnDisband() {
+        return this.global.isClearEnderChestOnDisband();
+    }
+
+    @Override
+    public boolean isClearEnderChestOnJoin() {
+        return this.global.isClearEnderChestOnJoin();
+    }
+
+    @Override
+    public boolean isClearInventoryOnDisband() {
+        return this.global.isClearInventoryOnDisband();
+    }
+
+    @Override
+    public boolean isClearInventoryOnJoin() {
+        return this.global.isClearInventoryOnJoin();
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
@@ -124,10 +124,6 @@ public class GlobalSection extends SettingsContainerHolder {
         return getContainer().stackedBlocksProvider;
     }
 
-    public boolean isDisbandInventoryClear() {
-        return getContainer().disbandInventoryClear;
-    }
-
     public boolean isTeleportOnJoin() {
         return getContainer().teleportOnJoin;
     }
@@ -136,8 +132,20 @@ public class GlobalSection extends SettingsContainerHolder {
         return getContainer().teleportOnKick;
     }
 
-    public boolean isClearOnJoin() {
-        return getContainer().clearOnJoin;
+    public boolean isClearEnderChestOnDisband() {
+        return getContainer().clearEnderChestOnDisband;
+    }
+
+    public boolean isClearEnderChestOnJoin() {
+        return getContainer().clearEnderChestOnDisband;
+    }
+
+    public boolean isClearInventoryOnDisband() {
+        return getContainer().clearInventoryOnDisband;
+    }
+
+    public boolean isClearInventoryOnJoin() {
+        return getContainer().clearInventoryOnJoin;
     }
 
     public boolean isRateOwnIsland() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -1778,7 +1778,9 @@ public class SIsland implements Island {
                 kickMember(islandMember);
             }
 
-            if (plugin.getSettings().isDisbandInventoryClear())
+            if (plugin.getSettings().isClearEnderChestOnDisband())
+                plugin.getNMSPlayers().clearEnderChest(islandMember.asOfflinePlayer());
+            if (plugin.getSettings().isClearInventoryOnDisband())
                 plugin.getNMSPlayers().clearInventory(islandMember.asOfflinePlayer());
 
             for (Mission<?> mission : plugin.getMissions().getPlayerMissions()) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/nms/NMSPlayers.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/nms/NMSPlayers.java
@@ -12,6 +12,8 @@ import java.util.Locale;
 
 public interface NMSPlayers {
 
+    void clearEnderChest(OfflinePlayer offlinePlayer);
+
     void clearInventory(OfflinePlayer offlinePlayer);
 
     void setSkinTexture(SuperiorPlayer superiorPlayer);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -458,9 +458,6 @@ spawners-provider: 'AUTO'
 # Providers: Auto, WildStacker, RoseStacker
 stacked-blocks-provider: 'AUTO'
 
-# Should inventories of island members get cleared after disbanding their island?
-disband-inventory-clear: true
-
 # All settings related to island names.
 island-names:
   # Should creation of islands will ask for name (/is create <name>)?
@@ -493,8 +490,17 @@ teleport-on-join: false
 # Should players get teleported to spawn when they are kicked from their island?
 teleport-on-kick: true
 
+# Should the Ender Chest of island members get cleared after disbanding their island?
+clear-ender-chest-on-disband: true
+
+# Should the Ender Chest of the players get cleared after they accept an invite?
+clear-ender-chest-on-join: false
+
+# Should the inventory of island members get cleared after disbanding their island?
+clear-inventory-on-disband: true
+
 # Should the inventory of the players get cleared after they accept an invite?
-clear-on-join: false
+clear-inventory-on-join: false
 
 # Should players be able to rate their own islands?
 rate-own-island: false


### PR DESCRIPTION
I changed the way the options that cleared the inventory during disband/join work a bit. I separated them into the Ender Chest and inventory clearing options, which meant I had to change the names of these options to make them fit together, but I don't know if I can do that, so you can let me know if I did it correctly.