### PR TITLE
Added separate permissions for commands that can be used on another island

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/commands/SuperiorCommand.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/commands/SuperiorCommand.java
@@ -48,14 +48,6 @@ public interface SuperiorCommand {
     int getMinArgs();
 
     /**
-     * Get the minimum arguments required for the command.
-     * For example, the command /is example PLAYER_NAME has 2 arguments.
-     *
-     * @param sender The sender who ran the command.
-     */
-    int getMinArgs(SuperiorSkyblock plugin, CommandSender sender);
-
-    /**
      * Get the maximum arguments required for the command.
      * For example, the command /is example PLAYER_NAME has 2 arguments.
      */

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/commands/SuperiorCommand.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/commands/SuperiorCommand.java
@@ -27,6 +27,14 @@ public interface SuperiorCommand {
     String getUsage(Locale locale);
 
     /**
+     * Get the usage of the sub command.
+     *
+     * @param sender The sender who ran the command.
+     * @param locale The locale of the player.
+     */
+    String getUsage(SuperiorSkyblock plugin, CommandSender sender, Locale locale);
+
+    /**
      * Get the description of the sub command.
      *
      * @param locale The locale of the player.
@@ -40,10 +48,26 @@ public interface SuperiorCommand {
     int getMinArgs();
 
     /**
+     * Get the minimum arguments required for the command.
+     * For example, the command /is example PLAYER_NAME has 2 arguments.
+     *
+     * @param sender The sender who ran the command.
+     */
+    int getMinArgs(SuperiorSkyblock plugin, CommandSender sender);
+
+    /**
      * Get the maximum arguments required for the command.
      * For example, the command /is example PLAYER_NAME has 2 arguments.
      */
     int getMaxArgs();
+
+    /**
+     * Get the maximum arguments required for the command.
+     * For example, the command /is example PLAYER_NAME has 2 arguments.
+     *
+     * @param sender The sender who ran the command.
+     */
+    int getMaxArgs(SuperiorSkyblock plugin, CommandSender sender);
 
     /**
      * Can the command be executed from console?

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -111,9 +111,10 @@ public interface SettingsManager {
     boolean isCoopMembers();
 
     /**
-     * Should players be able to edit island privileges for other players?
-     * Config path: edit-player-permissions
+     * Removed because introduced permission superior.island.permissions.other
+     * This method will be deleted in the future!
      */
+    @Deprecated
     boolean isEditPlayerPermissions();
 
     /**

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandsManagerImpl.java
@@ -267,9 +267,9 @@ public class CommandsManagerImpl extends Manager implements CommandsManager {
                         return false;
                     }
 
-                    if (args.length < command.getMinArgs() || args.length > command.getMaxArgs()) {
-                        Log.debugResult(Debug.EXECUTE_COMMAND, "Return Incorrect Usage", command.getUsage(locale));
-                        Message.COMMAND_USAGE.send(sender, locale, getLabel() + " " + command.getUsage(locale));
+                    if (args.length < command.getMinArgs(plugin, sender) || args.length > command.getMaxArgs(plugin, sender)) {
+                        Log.debugResult(Debug.EXECUTE_COMMAND, "Return Incorrect Usage", command.getUsage(plugin, sender, locale));
+                        Message.COMMAND_USAGE.send(sender, locale, getLabel() + " " + command.getUsage(plugin, sender, locale));
                         return false;
                     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandsManagerImpl.java
@@ -267,7 +267,7 @@ public class CommandsManagerImpl extends Manager implements CommandsManager {
                         return false;
                     }
 
-                    if (args.length < command.getMinArgs(plugin, sender) || args.length > command.getMaxArgs(plugin, sender)) {
+                    if (args.length < command.getMinArgs() || args.length > command.getMaxArgs(plugin, sender)) {
                         Log.debugResult(Debug.EXECUTE_COMMAND, "Return Incorrect Usage", command.getUsage(plugin, sender, locale));
                         Message.COMMAND_USAGE.send(sender, locale, getLabel() + " " + command.getUsage(plugin, sender, locale));
                         return false;

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/ISuperiorCommand.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/ISuperiorCommand.java
@@ -6,8 +6,51 @@ import com.bgsoftware.superiorskyblock.api.commands.SuperiorCommand;
 import org.bukkit.command.CommandSender;
 
 import java.util.List;
+import java.util.Locale;
 
 public interface ISuperiorCommand extends SuperiorCommand {
+
+    @Override
+    default String getUsage(Locale locale) {
+        return "";
+    }
+
+    @Override
+    default String getUsage(SuperiorSkyblock plugin, CommandSender sender, Locale locale) {
+        return getUsage((SuperiorSkyblockPlugin) plugin, sender, locale);
+    }
+
+    default String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, Locale locale) {
+        return getUsage(locale);
+    }
+
+    @Override
+    default int getMinArgs() {
+        return -1;
+    }
+
+    @Override
+    default int getMinArgs(SuperiorSkyblock plugin, CommandSender sender) {
+        return getMinArgs((SuperiorSkyblockPlugin) plugin, sender);
+    }
+
+    default int getMinArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return getMinArgs();
+    }
+
+    @Override
+    default int getMaxArgs() {
+        return -1;
+    }
+
+    @Override
+    default int getMaxArgs(SuperiorSkyblock plugin, CommandSender sender) {
+        return getMaxArgs((SuperiorSkyblockPlugin) plugin, sender);
+    }
+
+    default int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return getMaxArgs();
+    }
 
     @Override
     default boolean displayCommand() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/ISuperiorCommand.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/ISuperiorCommand.java
@@ -25,20 +25,6 @@ public interface ISuperiorCommand extends SuperiorCommand {
     }
 
     @Override
-    default int getMinArgs() {
-        return -1;
-    }
-
-    @Override
-    default int getMinArgs(SuperiorSkyblock plugin, CommandSender sender) {
-        return getMinArgs((SuperiorSkyblockPlugin) plugin, sender);
-    }
-
-    default int getMinArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
-        return getMinArgs();
-    }
-
-    @Override
     default int getMaxArgs() {
         return -1;
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdCounts.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdCounts.java
@@ -23,14 +23,18 @@ public class CmdCounts implements ISuperiorCommand {
 
     @Override
     public String getPermission() {
-        return "superior.island.counts";
+        return "superior.island.counts.self";
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        return "counts [" +
-                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
-                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (sender.hasPermission("superior.island.counts.others")) {
+            return "counts [" +
+                    Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                    Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+        } else {
+            return "counts";
+        }
     }
 
     @Override
@@ -44,8 +48,8 @@ public class CmdCounts implements ISuperiorCommand {
     }
 
     @Override
-    public int getMaxArgs() {
-        return 2;
+    public int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return sender.hasPermission("superior.island.counts.others") ? 2 : 1;
     }
 
     @Override
@@ -69,7 +73,8 @@ public class CmdCounts implements ISuperiorCommand {
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
         return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
+                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
+                onlineIsland != null && sender.hasPermission("superior.island.counts.others")) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdCounts.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdCounts.java
@@ -72,9 +72,9 @@ public class CmdCounts implements ISuperiorCommand {
 
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
-        return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
-                onlineIsland != null && sender.hasPermission("superior.island.counts.others")) : Collections.emptyList();
+        return args.length == 2 && sender.hasPermission("superior.island.counts.others") ?
+                CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
+                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdPermissions.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdPermissions.java
@@ -12,6 +12,7 @@ import com.bgsoftware.superiorskyblock.core.menu.view.MenuViewWrapper;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.island.privilege.IslandPrivileges;
 import com.bgsoftware.superiorskyblock.island.role.SPlayerRole;
+import org.bukkit.command.CommandSender;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,12 +31,12 @@ public class CmdPermissions implements IPermissibleCommand {
 
     @Override
     public String getPermission() {
-        return "superior.island.permissions";
+        return "superior.island.permissions.roles";
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        if (plugin.getSettings().isEditPlayerPermissions()) {
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (sender.hasPermission("superior.island.permissions.players")) {
             return "permissions [" + Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "] [reset]";
         } else {
             return "permissions [reset]";
@@ -53,8 +54,8 @@ public class CmdPermissions implements IPermissibleCommand {
     }
 
     @Override
-    public int getMaxArgs() {
-        return plugin.getSettings().isEditPlayerPermissions() ? 3 : 2;
+    public int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return sender.hasPermission("superior.island.permissions.players") ? 3 : 2;
     }
 
     @Override
@@ -78,7 +79,7 @@ public class CmdPermissions implements IPermissibleCommand {
 
         boolean setToDefault = (args.length == 2 ? args[1] : args.length == 3 ? args[2] : "").equalsIgnoreCase("reset");
 
-        if (plugin.getSettings().isEditPlayerPermissions() && ((!setToDefault && args.length == 2) || args.length == 3)) {
+        if (superiorPlayer.hasPermission("superior.island.permissions.players") && ((!setToDefault && args.length == 2) || args.length == 3)) {
             SuperiorPlayer targetPlayer = plugin.getPlayers().getSuperiorPlayer(args[1]);
 
             if (targetPlayer == null) {
@@ -124,11 +125,11 @@ public class CmdPermissions implements IPermissibleCommand {
         if (args.length == 2) {
             if ("reset".contains(args[1].toLowerCase(Locale.ENGLISH)))
                 tabVariables.add("reset");
-            if (plugin.getSettings().isEditPlayerPermissions()) {
+            if (superiorPlayer.hasPermission("superior.island.permissions.players")) {
                 tabVariables.addAll(CommandTabCompletes.getOnlinePlayers(plugin, args[1],
                         plugin.getSettings().isTabCompleteHideVanished()));
             }
-        } else if (plugin.getSettings().isEditPlayerPermissions() && args.length == 3) {
+        } else if (superiorPlayer.hasPermission("superior.island.permissions.players") && args.length == 3) {
             if ("reset".contains(args[2].toLowerCase(Locale.ENGLISH)))
                 tabVariables.add("reset");
         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdPermissions.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdPermissions.java
@@ -33,7 +33,7 @@ public class CmdPermissions implements IPermissibleCommand {
     }
 
     @Override
-    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, Locale locale) {
         if (sender.hasPermission("superior.island.permissions.players")) {
             return "permissions [" + Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "] [reset]";
         } else {
@@ -42,7 +42,7 @@ public class CmdPermissions implements IPermissibleCommand {
     }
 
     @Override
-    public String getDescription(java.util.Locale locale) {
+    public String getDescription(Locale locale) {
         return Message.COMMAND_DESCRIPTION_PERMISSIONS.getMessage(locale);
     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdPermissions.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdPermissions.java
@@ -22,8 +22,6 @@ import java.util.Locale;
 
 public class CmdPermissions implements IPermissibleCommand {
 
-    private static final SuperiorSkyblockPlugin plugin = SuperiorSkyblockPlugin.getPlugin();
-
     @Override
     public List<String> getAliases() {
         return Arrays.asList("permissions", "perms", "setpermission", "setperm");

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdShow.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdShow.java
@@ -149,9 +149,9 @@ public class CmdShow implements ISuperiorCommand {
 
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
-        return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
-                onlineIsland != null && sender.hasPermission("superior.island.show.others")) : Collections.emptyList();
+        return args.length == 2 && sender.hasPermission("superior.island.show.others") ?
+                CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
+                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdShow.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdShow.java
@@ -32,14 +32,18 @@ public class CmdShow implements ISuperiorCommand {
 
     @Override
     public String getPermission() {
-        return "superior.island.show";
+        return "superior.island.show.self";
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        return "show [" +
-                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
-                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (sender.hasPermission("superior.island.show.others")) {
+            return "show [" +
+                    Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                    Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+        } else {
+            return "show";
+        }
     }
 
     @Override
@@ -53,8 +57,8 @@ public class CmdShow implements ISuperiorCommand {
     }
 
     @Override
-    public int getMaxArgs() {
-        return 2;
+    public int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return sender.hasPermission("superior.island.show.others") ? 2 : 1;
     }
 
     @Override
@@ -64,8 +68,13 @@ public class CmdShow implements ISuperiorCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
-        Island island = args.length == 1 ? CommandArguments.getIslandWhereStanding(plugin, sender).getIsland() :
+        Island targetIsland = args.length == 1 ? CommandArguments.getIslandWhereStanding(plugin, sender).getIsland() :
                 CommandArguments.getIsland(plugin, sender, args[1]).getIsland();
+
+        SuperiorPlayer player = plugin.getPlayers().getSuperiorPlayer(sender);
+
+        final Island island = (!targetIsland.isMember(player) && !sender.hasPermission("superior.island.show.others")) ?
+                player.getIsland() : targetIsland;
 
         if (island == null)
             return;
@@ -141,7 +150,8 @@ public class CmdShow implements ISuperiorCommand {
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
         return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
+                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
+                onlineIsland != null && sender.hasPermission("superior.island.show.others")) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdTeam.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdTeam.java
@@ -31,14 +31,18 @@ public class CmdTeam implements ISuperiorCommand {
 
     @Override
     public String getPermission() {
-        return "superior.island.team";
+        return "superior.island.team.self";
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        return "team [" +
-                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
-                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (sender.hasPermission("superior.island.team.others")) {
+            return "team [" +
+                    Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                    Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+        } else {
+            return "team";
+        }
     }
 
     @Override
@@ -52,8 +56,8 @@ public class CmdTeam implements ISuperiorCommand {
     }
 
     @Override
-    public int getMaxArgs() {
-        return 2;
+    public int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return sender.hasPermission("superior.island.team.others") ? 2 : 1;
     }
 
     @Override
@@ -113,7 +117,8 @@ public class CmdTeam implements ISuperiorCommand {
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
         return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
+                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
+                onlineIsland != null && sender.hasPermission("superior.island.team.others")) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdTeam.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdTeam.java
@@ -116,9 +116,9 @@ public class CmdTeam implements ISuperiorCommand {
 
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
-        return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
-                onlineIsland != null && sender.hasPermission("superior.island.team.others")) : Collections.emptyList();
+        return args.length == 2 && sender.hasPermission("superior.island.team.others") ?
+                CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
+                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdToggle.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdToggle.java
@@ -27,8 +27,13 @@ public class CmdToggle implements ISuperiorCommand {
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        return "toggle <border/blocks>";
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (!sender.hasPermission("superior.island.toggle.border"))
+            return "toggle <blocks>";
+        else if (!sender.hasPermission("superior.island.toggle.blocks"))
+            return "toggle <border>";
+        else
+            return "toggle <blocks/border>";
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdValues.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdValues.java
@@ -73,9 +73,9 @@ public class CmdValues implements ISuperiorCommand {
 
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
-        return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
-                onlineIsland != null && sender.hasPermission("superior.island.values.others")) : Collections.emptyList();
+        return args.length == 2 && sender.hasPermission("superior.island.values.others") ?
+                CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
+                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdValues.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdValues.java
@@ -23,14 +23,18 @@ public class CmdValues implements ISuperiorCommand {
 
     @Override
     public String getPermission() {
-        return "superior.island.values";
+        return "superior.island.values.self";
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        return "values [" +
-                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
-                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (sender.hasPermission("superior.island.values.others")) {
+            return "values [" +
+                    Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                    Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+        } else {
+            return "values";
+        }
     }
 
     @Override
@@ -44,8 +48,8 @@ public class CmdValues implements ISuperiorCommand {
     }
 
     @Override
-    public int getMaxArgs() {
-        return 2;
+    public int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return sender.hasPermission("superior.island.values.others") ? 2 : 1;
     }
 
     @Override
@@ -70,7 +74,8 @@ public class CmdValues implements ISuperiorCommand {
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
         return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
+                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
+                onlineIsland != null && sender.hasPermission("superior.island.values.others")) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -106,7 +106,6 @@ public class SettingsContainer {
     public final boolean autoBlocksTracking;
     public final String islandTopOrder;
     public boolean coopMembers;
-    public boolean editPlayerPermissions;
     public final ConfigurationSection islandRolesSection;
     public final long calcInterval;
     public final String signWarpLine;
@@ -302,7 +301,6 @@ public class SettingsContainer {
         autoBlocksTracking = config.getBoolean("auto-blocks-tracking", true);
         islandTopOrder = config.getString("island-top-order", "WORTH").toUpperCase(Locale.ENGLISH);
         coopMembers = config.getBoolean("coop-members", true);
-        editPlayerPermissions = config.getBoolean("edit-player-permissions", true);
         islandRolesSection = config.getConfigurationSection("island-roles");
         signWarpLine = config.getString("sign-warp-line", "[IslandWarp]");
         List<String> signWarp = Formatters.formatList(config.getStringList("sign-warp"), Formatters.COLOR_FORMATTER);

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -159,7 +159,7 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
 
     @Override
     public boolean isEditPlayerPermissions() {
-        return this.global.isEditPlayerPermissions();
+        return true;
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
@@ -61,10 +61,6 @@ public class GlobalSection extends SettingsContainerHolder {
         return getContainer().coopMembers;
     }
 
-    public boolean isEditPlayerPermissions() {
-        return getContainer().editPlayerPermissions;
-    }
-
     public String getSignWarpLine() {
         return getContainer().signWarpLine;
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdBalance.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdBalance.java
@@ -23,14 +23,18 @@ public class CmdBalance implements ISuperiorCommand {
 
     @Override
     public String getPermission() {
-        return "superior.island.balance";
+        return "superior.island.balance.self";
     }
 
     @Override
-    public String getUsage(java.util.Locale locale) {
-        return "balance [" +
-                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
-                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+    public String getUsage(SuperiorSkyblockPlugin plugin, CommandSender sender, java.util.Locale locale) {
+        if (sender.hasPermission("superior.island.balance.others")) {
+            return "balance [" +
+                    Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                    Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
+        } else {
+            return "balance";
+        }
     }
 
     @Override
@@ -44,8 +48,8 @@ public class CmdBalance implements ISuperiorCommand {
     }
 
     @Override
-    public int getMaxArgs() {
-        return 2;
+    public int getMaxArgs(SuperiorSkyblockPlugin plugin, CommandSender sender) {
+        return sender.hasPermission("superior.island.balance.others") ? 2 : 1;
     }
 
     @Override
@@ -77,7 +81,8 @@ public class CmdBalance implements ISuperiorCommand {
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
         return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
+                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
+                onlineIsland != null && sender.hasPermission("superior.island.balance.others")) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdBalance.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdBalance.java
@@ -80,9 +80,9 @@ public class CmdBalance implements ISuperiorCommand {
 
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
-        return args.length == 2 ? CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
-                plugin.getSettings().isTabCompleteHideVanished(), (onlinePlayer, onlineIsland) ->
-                onlineIsland != null && sender.hasPermission("superior.island.balance.others")) : Collections.emptyList();
+        return args.length == 2 && sender.hasPermission("superior.island.balance.others") ?
+                CommandTabCompletes.getPlayerIslandsExceptSender(plugin, sender, args[1],
+                plugin.getSettings().isTabCompleteHideVanished()) : Collections.emptyList();
     }
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -178,10 +178,6 @@ island-top-order: 'WORTH'
 # Whether coop members should be enabled or not.
 coop-members: true
 
-# Should players be able to edit island privileges for other players?
-# When set to false, island privileges could be edited only to island roles.
-edit-player-permissions: true
-
 # All settings related to island roles.
 # You can find a list of permissions here: https://wiki.bg-software.com/superiorskyblock/island-permissions
 island-roles:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -57,6 +57,11 @@ permissions:
             description: Accept an invitation from a player.
           superior.island.balance:
             description: Check the amount of money inside an island's bank.
+            children:
+              superior.island.balance.others:
+                description: Check the amount of money inside another island's bank.
+              superior.island.balance.self:
+                description: Check the amount of money inside your island's bank.
           superior.island.ban:
             description: Ban a player from your island.
           superior.island.bank:
@@ -74,7 +79,12 @@ permissions:
           superior.island.coops:
             description: Open the coops menu.
           superior.island.counts:
-            description: See block counts in your island.
+            description: See block counts in island.
+            children:
+              superior.island.counts.others:
+                description: See block counts in another player's island.
+              superior.island.counts.self:
+                description: See block counts in your island.
           superior.island.create:
             description: Create a new island.
           superior.island.delwarp:
@@ -112,7 +122,12 @@ permissions:
           superior.island.pardon:
             description: Unban a player from your island.
           superior.island.permissions:
-            description: Get all permissions for an island role.
+            description: Get all permissions.
+            children:
+              superior.island.permissions.players:
+                description: Get all permissions for an player on the island.
+              superior.island.permissions.roles:
+                description: Get all permissions for an island role.
           superior.island.promote:
             description: Promote a member in your island.
           superior.island.rankup:
@@ -137,10 +152,20 @@ permissions:
             description: Create a new island warp.
           superior.island.show:
             description: Get information about an island.
+            children:
+              superior.island.show.others:
+                description: Get information about another player's island.
+              superior.island.show.self:
+                description: Get information about your island.
           superior.island.stacker.*:
             description: Gives the ability to stack blocks.
           superior.island.team:
             description: Get information about island members status.
+            children:
+              superior.island.team.others:
+                description: Get information about members of another island.
+              superior.island.team.self:
+                description: Get information about members of your island.
           superior.island.teamchat:
             description: Toggle team chat mode.
           superior.island.teleport:
@@ -164,6 +189,11 @@ permissions:
             description: Get the worth value of a block.
           superior.island.values:
             description: Open the values menu.
+            children:
+              superior.island.values.others:
+                description: Open the values menu of another island.
+              superior.island.values.self:
+                description: Open the values menu of your island.
           superior.island.visit:
             description: Teleport to the visitors location of an island.
           superior.island.warp:


### PR DESCRIPTION
Fixes issue #2514 

Currently, I've made it so that if a player has the old permission, they can use both functions, just like before. If a player only has the .self permission, they can use the command without an argument, and if they only have the .other permission, they can't use the command at all (.other is just an extension of .self). I did it this way because you wanted to avoid having to change the granted permissions after introducing this function. However, I think this solution is quite confusing, and it would be better to separate these permissions – the old permission would grant access to the command without an argument, and the additional .other permission would allow the command to use an argument (this permission would also be an extension of the default permission, but it wouldn't be a children, but a separate permission). Let me know what you think.