### PR TITLE
Changed disband count option behavior to allow setting 0 disbands by default

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -190,7 +190,10 @@ public interface SettingsManager {
      * The default amount of disbands players receive when they first join the server.
      * If 0, then the disbands limit is disabled.
      * Config-path: disband-count
+     *
+     * @deprecated see {@link #getDefaultDisbandCount()}
      */
+    @Deprecated
     int getDisbandCount();
 
     /**
@@ -463,6 +466,13 @@ public interface SettingsManager {
      * Config-path: build-outside-island
      */
     boolean isBuildOutsideIsland();
+
+    /**
+     * The default number of disbands players receive when they first join the server.
+     * If set to -1, players will have unlimited disbands.
+     * Config-path: default-disband-count
+     */
+    int getDefaultDisbandCount();
 
     /**
      * The default language to be set for new players.

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdDisband.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdDisband.java
@@ -67,7 +67,7 @@ public class CmdDisband implements IPermissibleCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, SuperiorPlayer superiorPlayer, Island island, String[] args) {
-        if (!superiorPlayer.hasDisbands() && plugin.getSettings().getDisbandCount() > 0) {
+        if (!superiorPlayer.hasDisbands()) {
             Message.NO_MORE_DISBANDS.send(superiorPlayer);
             return;
         }
@@ -84,7 +84,10 @@ public class CmdDisband implements IPermissibleCommand {
                         island.getIslandBank().getBalance().multiply(BigDecimal.valueOf(BuiltinModules.BANK.disbandRefund))));
             }
 
-            superiorPlayer.setDisbands(superiorPlayer.getDisbands() - 1);
+            if (superiorPlayer.getDisbands() > 0) {
+                superiorPlayer.setDisbands(superiorPlayer.getDisbands() - 1);
+            }
+
             island.disbandIsland();
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -134,7 +134,6 @@ public class SettingsContainer {
     public final KeySet safeBlocks;
     public final boolean visitorsDamage;
     public final boolean coopDamage;
-    public final int disbandCount;
     public final boolean islandTopIncludeLeader;
     public final Map<String, String> defaultPlaceholders;
     public final boolean banConfirm;
@@ -186,6 +185,7 @@ public class SettingsContainer {
     public final int cropsInterval;
     public final boolean onlyBackButton;
     public final boolean buildOutsideIsland;
+    public final int defaultDisbandCount;
     public final String defaultLanguage;
     public final boolean defaultWorldBorder;
     public final boolean defaultBlocksStacker;
@@ -375,7 +375,6 @@ public class SettingsContainer {
         safeBlocks = loadSafeBlocks(plugin);
         visitorsDamage = config.getBoolean("visitors-damage", false);
         coopDamage = config.getBoolean("coop-damage", true);
-        disbandCount = config.getInt("disband-count", 5);
         islandTopIncludeLeader = config.getBoolean("island-top-include-leader", true);
         defaultPlaceholders = Collections.unmodifiableMap(config.getStringList("default-placeholders").stream().collect(Collectors.toMap(
                 line -> line.split(":")[0].replace("superior_", "").toLowerCase(Locale.ENGLISH),
@@ -495,6 +494,7 @@ public class SettingsContainer {
         cropsInterval = config.getInt("crops-interval", 5);
         onlyBackButton = config.getBoolean("only-back-button", false);
         buildOutsideIsland = config.getBoolean("build-outside-island", false);
+        defaultDisbandCount = config.getInt("default-disband-count", 5);
         defaultLanguage = config.getString("default-language", "en-US");
         defaultWorldBorder = config.getBoolean("default-world-border", true);
         defaultBlocksStacker = config.getBoolean("default-blocks-stacker", true);

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -443,6 +443,11 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     @Override
+    public int getDefaultDisbandCount() {
+        return this.global.getDefaultDisbandCount();
+    }
+
+    @Override
     public String getDefaultLanguage() {
         return this.global.getDefaultLanguage();
     }
@@ -661,6 +666,10 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     private void convertData(YamlConfiguration cfg) {
+        if (cfg.contains("disband-count")) {
+            cfg.set("default-disband-count", cfg.getInt("disband-count") == 0 ? -1 : cfg.getInt("disband-count"));
+            cfg.set("disband-count", null);
+        }
         if (cfg.contains("default-hoppers-limit")) {
             cfg.set("default-limits", Collections.singletonList("HOPPER:" + cfg.getInt("default-hoppers-limit")));
             cfg.set("default-hoppers-limit", null);

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
@@ -94,7 +94,7 @@ public class GlobalSection extends SettingsContainerHolder {
     }
 
     public int getDisbandCount() {
-        return getContainer().disbandCount;
+        return getContainer().defaultDisbandCount;
     }
 
     public boolean isIslandTopIncludeLeader() {
@@ -255,6 +255,10 @@ public class GlobalSection extends SettingsContainerHolder {
 
     public boolean isBuildOutsideIsland() {
         return getContainer().buildOutsideIsland;
+    }
+
+    public int getDefaultDisbandCount() {
+        return getContainer().defaultDisbandCount;
     }
 
     public String getDefaultLanguage() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/button/impl/DisbandButton.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/button/impl/DisbandButton.java
@@ -48,7 +48,9 @@ public class DisbandButton extends AbstractMenuViewButton<IslandMenuView> {
                         targetIsland.getIslandBank().getBalance().multiply(BigDecimal.valueOf(BuiltinModules.BANK.disbandRefund))));
             }
 
-            inventoryViewer.setDisbands(inventoryViewer.getDisbands() - 1);
+            if (inventoryViewer.getDisbands() > 0) {
+                inventoryViewer.setDisbands(inventoryViewer.getDisbands() - 1);
+            }
 
             targetIsland.disbandIsland();
         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/player/SSuperiorPlayer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/player/SSuperiorPlayer.java
@@ -568,8 +568,6 @@ public class SSuperiorPlayer implements SuperiorPlayer {
 
     @Override
     public void setDisbands(int disbands) {
-        disbands = Math.max(disbands, 0);
-
         Log.debug(Debug.SET_DISBANDS, getName(), disbands);
 
         if (this.disbands == disbands)
@@ -582,7 +580,7 @@ public class SSuperiorPlayer implements SuperiorPlayer {
 
     @Override
     public boolean hasDisbands() {
-        return disbands > 0;
+        return disbands != 0;
     }
 
     /*

--- a/src/main/java/com/bgsoftware/superiorskyblock/player/builder/SuperiorPlayerBuilderImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/player/builder/SuperiorPlayerBuilderImpl.java
@@ -24,7 +24,7 @@ public class SuperiorPlayerBuilderImpl implements SuperiorPlayer.Builder {
     public UUID uuid = null;
     public String name = "null";
     public PlayerRole playerRole = SPlayerRole.guestRole();
-    public int disbands = plugin.getSettings().getDisbandCount();
+    public int disbands = plugin.getSettings().getDefaultDisbandCount();
     public Locale locale = PlayerLocales.getDefaultLocale();
     public String textureValue = "";
     public long lastTimeUpdated = -1;
@@ -79,7 +79,6 @@ public class SuperiorPlayerBuilderImpl implements SuperiorPlayer.Builder {
 
     @Override
     public SuperiorPlayer.Builder setDisbands(int disbands) {
-        Preconditions.checkArgument(disbands >= 0, "Cannot set negative disbands count.");
         this.disbands = disbands;
         return this;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -429,10 +429,6 @@ visitors-damage: false
 # When disabled, coop won't get damaged in islands they are coop with.
 coop-damage: true
 
-# The amount of times a player can disband an island.
-# If you want to disable this feature, set it to 0.
-disband-count: 5
-
 # Should the list of members in island top also include the island leader?
 island-top-include-leader: true
 
@@ -723,6 +719,10 @@ only-back-button: false
 # All islands will have the size of the max-island-size * 1.5, which means islands will be connected to each other.
 # It's recommended to have a low max island size when this feature is enabled!
 build-outside-island: false
+
+# The default number of times new players can disband their island.
+# If set to -1, new players will have unlimited disbands.
+default-disband-count: 5
 
 # The default language to be used.
 # This should be the same as your language file's name.


### PR DESCRIPTION
I've changed the disband-count option to default-disband-count, and its behavior. Previously, you couldn't set new players to have 0 disbands, because 0 meant the option was disabled. Now, the option can't be disabled, but -1 (or lower) means you have an infinite number of disbands. Disbands are only taken if the player has a positive amount of them. If the old option was set to 0 in the config, the new option will have a value of -1.