### PR TITLE
Fixed control panel button actions

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/button/impl/ControlPanelButton.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/button/impl/ControlPanelButton.java
@@ -32,30 +32,17 @@ public class ControlPanelButton extends AbstractMenuViewButton<IslandMenuView> {
 
     @Override
     public void onButtonClick(InventoryClickEvent clickEvent) {
-        SuperiorPlayer inventoryViewer = menuView.getInventoryViewer();
-        Island targetIsland = menuView.getIsland();
-
         switch (getTemplate().controlPanelAction) {
             case OPEN_MEMBERS:
-                plugin.getMenus().openMembers(inventoryViewer, MenuViewWrapper.fromView(menuView), targetIsland);
+                plugin.getCommands().dispatchSubCommand(clickEvent.getWhoClicked(), "members");
                 break;
             case OPEN_SETTINGS:
-                if (inventoryViewer.hasPermission("superior.island.settings")) {
-                    if (!inventoryViewer.hasPermission(IslandPrivileges.SET_SETTINGS)) {
-                        Message.NO_SET_SETTINGS_PERMISSION.send(inventoryViewer,
-                                targetIsland.getRequiredPlayerRole(IslandPrivileges.SET_SETTINGS));
-                        return;
-                    }
-
-                    plugin.getMenus().openSettings(inventoryViewer, MenuViewWrapper.fromView(menuView), targetIsland);
-                }
+                plugin.getCommands().dispatchSubCommand(clickEvent.getWhoClicked(), "settings");
                 break;
             case OPEN_VISITORS:
-                plugin.getMenus().openVisitors(inventoryViewer, MenuViewWrapper.fromView(menuView), targetIsland);
+                plugin.getCommands().dispatchSubCommand(clickEvent.getWhoClicked(), "visitors");
                 break;
         }
-
-        BukkitExecutor.sync(menuView::closeView, 1L);
     }
 
     public enum ControlPanelAction {

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/button/impl/ControlPanelButton.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/button/impl/ControlPanelButton.java
@@ -1,19 +1,13 @@
 package com.bgsoftware.superiorskyblock.core.menu.button.impl;
 
 import com.bgsoftware.common.annotations.Nullable;
-import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.menu.button.MenuTemplateButton;
 import com.bgsoftware.superiorskyblock.api.world.GameSound;
-import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.core.menu.TemplateItem;
 import com.bgsoftware.superiorskyblock.core.menu.button.AbstractMenuTemplateButton;
 import com.bgsoftware.superiorskyblock.core.menu.button.AbstractMenuViewButton;
 import com.bgsoftware.superiorskyblock.core.menu.button.MenuTemplateButtonImpl;
 import com.bgsoftware.superiorskyblock.core.menu.view.impl.IslandMenuView;
-import com.bgsoftware.superiorskyblock.core.menu.view.MenuViewWrapper;
-import com.bgsoftware.superiorskyblock.core.messages.Message;
-import com.bgsoftware.superiorskyblock.core.threads.BukkitExecutor;
-import com.bgsoftware.superiorskyblock.island.privilege.IslandPrivileges;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
 import java.util.List;


### PR DESCRIPTION
The Control Panel button action didn't check permissions for members and visitors (this is necessary because separate permissions have recently been added to these commands); it only checked them for settings. But it still didn't do it correctly, as it didn't return an error message. So I changed the menu opening to command dispatching, which will automatically check all requirements. I also removed the menu closing action, as it caused the cursor to jump from the clicked location to the middle slot on the bottom menu line.