### PR TITLE
Added built-in placeholders to some menu titles

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandBannedPlayers.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandBannedPlayers.java
@@ -55,6 +55,11 @@ public class MenuIslandBannedPlayers extends AbstractPagedMenu<MenuIslandBannedP
         }
 
         @Override
+        public String replaceTitle(String title) {
+            return title.replace("{0}", String.valueOf(island.getBannedPlayers().size()));
+        }
+
+        @Override
         protected List<SuperiorPlayer> requestObjects() {
             return island.getBannedPlayers();
         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandMembers.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandMembers.java
@@ -62,6 +62,12 @@ public class MenuIslandMembers extends AbstractPagedMenu<MenuIslandMembers.View,
         }
 
         @Override
+        public String replaceTitle(String title) {
+            return title.replace("{0}", String.valueOf(island.getIslandMembers(true).size())).
+                    replace("{1}", String.valueOf(island.getTeamLimit()));
+        }
+
+        @Override
         protected List<SuperiorPlayer> requestObjects() {
             return island.getIslandMembers(true);
         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandRatings.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandRatings.java
@@ -70,6 +70,11 @@ public class MenuIslandRatings extends AbstractPagedMenu<MenuIslandRatings.View,
         }
 
         @Override
+        public String replaceTitle(String title) {
+            return title.replace("{0}", String.valueOf(island.getTotalRating()));
+        }
+
+        @Override
         protected List<RatingInfo> requestObjects() {
             return new SequentialListBuilder<RatingInfo>()
                     .build(island.getRatings().entrySet(), RATING_INFO_MAPPER);

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandVisitors.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandVisitors.java
@@ -77,6 +77,11 @@ public class MenuIslandVisitors extends AbstractPagedMenu<MenuIslandVisitors.Vie
         }
 
         @Override
+        public String replaceTitle(String title) {
+            return title.replace("{0}", String.valueOf(island.getIslandVisitors(false).size()));
+        }
+
+        @Override
         protected List<SuperiorPlayer> requestObjects() {
             return island.getIslandVisitors(false);
         }

--- a/src/main/resources/menus/banned-players.yml
+++ b/src/main/resources/menus/banned-players.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Banned Players'
+title: '&lIsland Banned Players ({0})'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/banned-players1_12.yml
+++ b/src/main/resources/menus/banned-players1_12.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Banned Players'
+title: '&lIsland Banned Players ({0})'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/banned-players1_13.yml
+++ b/src/main/resources/menus/banned-players1_13.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Banned Players'
+title: '&lIsland Banned Players ({0})'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/island-ratings.yml
+++ b/src/main/resources/menus/island-ratings.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Ratings (%superior_island_rating%/5)'
+title: '&lIsland Ratings ({0}/5)'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/island-ratings1_13.yml
+++ b/src/main/resources/menus/island-ratings1_13.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Ratings (%superior_island_rating%/5)'
+title: '&lIsland Ratings ({0}/5)'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/members.yml
+++ b/src/main/resources/menus/members.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Members'
+title: '&lIsland Members ({0}/{1})'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/members1_12.yml
+++ b/src/main/resources/menus/members1_12.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Members'
+title: '&lIsland Members ({0}/{1})'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/members1_13.yml
+++ b/src/main/resources/menus/members1_13.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Members'
+title: '&lIsland Members ({0}/{1})'
 previous-menu: true
 
 pattern:

--- a/src/main/resources/menus/unique-visitors.yml
+++ b/src/main/resources/menus/unique-visitors.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Visitors ({0})'
+title: '&lIsland Unique Visitors ({0})'
 previous-menu: true
 
 pattern:
@@ -29,6 +29,9 @@ items:
     lore:
       - '&7Island Owner: {1}'
       - '&7Last Time Joined: {3}'
+      - ''
+      - '&7Left-Click to expel the player.'
+      - '&7Right-Click to invite the player.'
   '%':
     type: PAPER
     name: '{0}Previous Page'

--- a/src/main/resources/menus/unique-visitors1_12.yml
+++ b/src/main/resources/menus/unique-visitors1_12.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Visitors ({0})'
+title: '&lIsland Unique Visitors ({0})'
 previous-menu: true
 
 pattern:
@@ -29,6 +29,9 @@ items:
     lore:
       - '&7Island Owner: {1}'
       - '&7Last Time Joined: {3}'
+      - ''
+      - '&7Left-Click to expel the player.'
+      - '&7Right-Click to invite the player.'
   '%':
     type: PAPER
     name: '{0}Previous Page'

--- a/src/main/resources/menus/unique-visitors1_13.yml
+++ b/src/main/resources/menus/unique-visitors1_13.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Visitors ({0})'
+title: '&lIsland Unique Visitors ({0})'
 previous-menu: true
 
 pattern:
@@ -28,6 +28,9 @@ items:
     lore:
       - '&7Island Owner: {1}'
       - '&7Last Time Joined: {3}'
+      - ''
+      - '&7Left-Click to expel the player.'
+      - '&7Right-Click to invite the player.'
   '%':
     type: PAPER
     name: '{0}Previous Page'

--- a/src/main/resources/menus/visitors.yml
+++ b/src/main/resources/menus/visitors.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Visitors'
+title: '&lIsland Visitors ({0})'
 previous-menu: true
 
 pattern:
@@ -29,6 +29,9 @@ items:
     name: '&e{0}'
     lore:
       - '&7Island Owner: {1}'
+      - ''
+      - '&7Left-Click to expel the player.'
+      - '&7Right-Click to invite the player.'
   '%':
     type: PAPER
     name: '{0}Previous Page'

--- a/src/main/resources/menus/visitors1_12.yml
+++ b/src/main/resources/menus/visitors1_12.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Visitors'
+title: '&lIsland Visitors ({0})'
 previous-menu: true
 
 pattern:
@@ -29,6 +29,9 @@ items:
     name: '&e{0}'
     lore:
       - '&7Island Owner: {1}'
+      - ''
+      - '&7Left-Click to expel the player.'
+      - '&7Right-Click to invite the player.'
   '%':
     type: PAPER
     name: '{0}Previous Page'

--- a/src/main/resources/menus/visitors1_13.yml
+++ b/src/main/resources/menus/visitors1_13.yml
@@ -5,7 +5,7 @@
 ##                                                  ##
 ######################################################
 
-title: '&lIsland Visitors'
+title: '&lIsland Visitors ({0})'
 previous-menu: true
 
 pattern:
@@ -28,6 +28,9 @@ items:
     name: '&e{0}'
     lore:
       - '&7Island Owner: {1}'
+      - ''
+      - '&7Left-Click to expel the player.'
+      - '&7Right-Click to invite the player.'
   '%':
     type: PAPER
     name: '{0}Previous Page'


### PR DESCRIPTION
# Changelog #
- Added player count display in the title to the Banned Players, Members and Visitors menus (just like in the Coops and Unique Visitors menus).
- Changed the title of the Unique Visitors menu so it no looks the same as the Visitors menu.
- Added descriptions to player items in Unique Visitors and Visitors menus to show which clicks trigger which action.
- Added island rating in the title to the Island Ratings menu (this was already added, but previously it used PlaceholderAPI, not the built-in placeholder)