### PR TITLE
Disabled display of empty data in island info

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminShow.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminShow.java
@@ -150,12 +150,14 @@ public class CmdAdminShow implements IAdminIslandCommand {
             infoMessage.append(Message.ISLAND_INFO_LEVEL.getMessage(locale, island.getIslandLevel())).append("\n");
 
         // Island discord
-        if (!Message.ISLAND_INFO_DISCORD.isEmpty(locale))
+        if (!Message.ISLAND_INFO_DISCORD.isEmpty(locale) && !"None".equals(island.getDiscord())) {
             infoMessage.append(Message.ISLAND_INFO_DISCORD.getMessage(locale, island.getDiscord())).append("\n");
+        }
 
         // Island paypal
-        if (!Message.ISLAND_INFO_PAYPAL.isEmpty(locale))
+        if (!Message.ISLAND_INFO_PAYPAL.isEmpty(locale) && !"None".equals(island.getPaypal())) {
             infoMessage.append(Message.ISLAND_INFO_PAYPAL.getMessage(locale, island.getPaypal())).append("\n");
+        }
 
         boolean upgradesModule = BuiltinModules.UPGRADES.isEnabled();
 
@@ -239,8 +241,9 @@ public class CmdAdminShow implements IAdminIslandCommand {
                             generatorString.append(" ").append(Message.ISLAND_INFO_ADMIN_VALUE_SYNCED.getMessage(locale));
                         generatorString.append("\n");
                     }
-                    infoMessage.append(Message.ISLAND_INFO_ADMIN_GENERATOR_RATES.getMessage(locale, generatorString,
-                            Formatters.CAPITALIZED_FORMATTER.format(dimension.getName())));
+                    if (generatorString.length() > 0)
+                        infoMessage.append(Message.ISLAND_INFO_ADMIN_GENERATOR_RATES.getMessage(locale, generatorString,
+                                Formatters.CAPITALIZED_FORMATTER.format(dimension.getName())));
                 }
             }
         }
@@ -270,8 +273,11 @@ public class CmdAdminShow implements IAdminIslandCommand {
 
             rolesStrings.keySet().stream()
                     .sorted(Collections.reverseOrder(Comparator.comparingInt(PlayerRole::getWeight)))
-                    .forEach(playerRole ->
-                            infoMessage.append(Message.ISLAND_INFO_ROLES.getMessage(locale, playerRole, rolesStrings.get(playerRole))));
+                    .forEach(playerRole -> {
+                        StringBuilder players = rolesStrings.get(playerRole);
+                        if (players != null && players.length() > 0)
+                            infoMessage.append(Message.ISLAND_INFO_ROLES.getMessage(locale, playerRole, players));
+                    });
         }
 
         if (!Message.ISLAND_INFO_FOOTER.isEmpty(locale))
@@ -308,7 +314,7 @@ public class CmdAdminShow implements IAdminIslandCommand {
             dataValue.append("\n");
         });
 
-        return Optional.of(dataValue);
+        return dataValue.length() > 0 ? Optional.of(dataValue) : Optional.empty();
     }
 
     private static <T> void collectIslandData(Locale locale, StringBuilder message,

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdShow.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdShow.java
@@ -100,12 +100,14 @@ public class CmdShow implements ISuperiorCommand {
             infoMessage.append(Message.ISLAND_INFO_WORTH.getMessage(locale, island.getWorth())).append("\n");
         if (!Message.ISLAND_INFO_LEVEL.isEmpty(locale))
             infoMessage.append(Message.ISLAND_INFO_LEVEL.getMessage(locale, island.getIslandLevel())).append("\n");
-        if (!Message.ISLAND_INFO_DISCORD.isEmpty(locale) && island.hasPermission(sender, IslandPrivileges.DISCORD_SHOW))
+        if (!Message.ISLAND_INFO_DISCORD.isEmpty(locale) && !"None".equals(island.getDiscord()) && island.hasPermission(sender, IslandPrivileges.DISCORD_SHOW)) {
             infoMessage.append(Message.ISLAND_INFO_DISCORD.getMessage(locale, island.getDiscord())).append("\n");
-        if (!Message.ISLAND_INFO_PAYPAL.isEmpty(locale) && island.hasPermission(sender, IslandPrivileges.PAYPAL_SHOW))
+        }
+        if (!Message.ISLAND_INFO_PAYPAL.isEmpty(locale) && !"None".equals(island.getPaypal()) && island.hasPermission(sender, IslandPrivileges.PAYPAL_SHOW)) {
             infoMessage.append(Message.ISLAND_INFO_PAYPAL.getMessage(locale, island.getPaypal())).append("\n");
+        }
         if (!Message.ISLAND_INFO_VISITORS_COUNT.isEmpty(locale))
-            infoMessage.append(Message.ISLAND_INFO_VISITORS_COUNT.getMessage(locale, island.getUniqueVisitorsWithTimes().size())).append("\n");
+            infoMessage.append(Message.ISLAND_INFO_VISITORS_COUNT.getMessage(locale, island.getIslandVisitors(false).size(), island.getUniqueVisitorsWithTimes().size())).append("\n");
 
         if (!Message.ISLAND_INFO_ROLES.isEmpty(locale)) {
             Map<PlayerRole, StringBuilder> rolesStrings = new ArrayMap<>();
@@ -128,8 +130,11 @@ public class CmdShow implements ISuperiorCommand {
 
             rolesStrings.keySet().stream()
                     .sorted(Collections.reverseOrder(Comparator.comparingInt(PlayerRole::getWeight)))
-                    .forEach(playerRole ->
-                            infoMessage.append(Message.ISLAND_INFO_ROLES.getMessage(locale, playerRole, rolesStrings.get(playerRole))));
+                    .forEach(playerRole -> {
+                        StringBuilder players = rolesStrings.get(playerRole);
+                        if (players != null && players.length() > 0)
+                            infoMessage.append(Message.ISLAND_INFO_ROLES.getMessage(locale, playerRole, players));
+                    });
         }
 
         if (!Message.ISLAND_INFO_FOOTER.isEmpty(locale))

--- a/src/main/resources/lang/de-DE.yml
+++ b/src/main/resources/lang/de-DE.yml
@@ -608,7 +608,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |-
   &e&lInsel | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lInsel | &7Besucheranzahl: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lInsel | &7Besucheranzahl: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lInsel | &7Wert: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lIsland | &7Die Insel wurde erfolgreich der Öffentlichkeit zugänglich

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -490,7 +490,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lIsland | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lIsland | &7Visitors Count: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lIsland | &7Visitors Count: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lIsland | &7Worth: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lIsland | &7Successfully opened the island to the public.'

--- a/src/main/resources/lang/es-ES.yml
+++ b/src/main/resources/lang/es-ES.yml
@@ -490,7 +490,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lIsla | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lIsla | &7Número de visitantes: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lIsla | &7Número de visitantes: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lIsla | &7Valor: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lIsla | &7Abrió con éxito la isla al público.'

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -492,7 +492,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lIle | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lIle | &7Nombre de visiteurs: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lIle | &7Nombre de visiteurs: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lIle | &7Valeur: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lIle | &7L''île est désormais ouverte au public.'

--- a/src/main/resources/lang/it-IT.yml
+++ b/src/main/resources/lang/it-IT.yml
@@ -498,7 +498,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lIsola | &7{0}:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lIsola | &7Numero di visitatori: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lIsola | &7Numero di visitatori: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lIsola | &7Valore: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lIsola | &7Aperta con successo l''isola al pubblico.'

--- a/src/main/resources/lang/iw-IL.yml
+++ b/src/main/resources/lang/iw-IL.yml
@@ -508,7 +508,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lיא | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lיא | &7םירקבמ רפסמ: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lIsland | &7Visitors Count: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lיא | &7יווש: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lיא | &7החלצהב רוביצל חתפנ יאה.'

--- a/src/main/resources/lang/pl-PL.yml
+++ b/src/main/resources/lang/pl-PL.yml
@@ -490,7 +490,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lWyspa | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lWyspa | &7Odwiedzajacy: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lWyspa | &7Odwiedzajacy: {0} ({1} unikalnych odwiedzajacych)'
 ISLAND_INFO_WORTH: '&e&lWyspa | &7Wartosc: {0}'
 ISLAND_NAME_NONE: Brak
 ISLAND_OPENED: '&e&lWyspa | &7Pomyslnie zmieniles status wyspy na publiczny.'

--- a/src/main/resources/lang/pt-BR.yml
+++ b/src/main/resources/lang/pt-BR.yml
@@ -490,7 +490,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lIlha | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lIlha | &7Contagem de visitantes: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lIlha | &7Contagem de visitantes: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lIlha | &7Valor: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lIlha | &7A ilha foi aberta com sucesso ao público.'

--- a/src/main/resources/lang/ru-RU.yml
+++ b/src/main/resources/lang/ru-RU.yml
@@ -490,7 +490,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lОстров | &7{0}ы:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lОстров | &7Количество посетителей: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lОстров | &7Количество посетителей: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lОстров | &7Стоимость: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lОстров | &7Остров успешно открыт для публики.'

--- a/src/main/resources/lang/tr-TR.yml
+++ b/src/main/resources/lang/tr-TR.yml
@@ -579,7 +579,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lAda | &7{0}lar:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lAda | &7Ziyaretçi Sayısı: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lAda | &7Ziyaretçi Sayısı: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lAda | &7Değer: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lAda | &7Ada başarıyla halka açıldı.'

--- a/src/main/resources/lang/vi-VN.yml
+++ b/src/main/resources/lang/vi-VN.yml
@@ -546,7 +546,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&lĐảo | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&lĐảo | &7Số lượt khách: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&lĐảo | &7Số lượt khách: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&lĐảo | &7Đáng giá: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&lĐảo | &7Mở đảo thành công cho công cộng.'

--- a/src/main/resources/lang/zh-CN.yml
+++ b/src/main/resources/lang/zh-CN.yml
@@ -490,7 +490,7 @@ ISLAND_INFO_RATE_FIVE_COLOR: '&2'
 ISLAND_INFO_ROLES: |
   &e&l岛屿 | &7{0}s:
   {1}
-ISLAND_INFO_VISITORS_COUNT: '&e&l岛屿 | &7访客数量: {0}'
+ISLAND_INFO_VISITORS_COUNT: '&e&l岛屿 | &7访客数量: {0} ({1} unique visitors)'
 ISLAND_INFO_WORTH: '&e&l岛屿 | &7价值: {0}'
 ISLAND_NAME_NONE: None
 ISLAND_OPENED: '&e&l岛屿 | &7成功将岛屿设置为对公众开放.'


### PR DESCRIPTION
I disabled the display of empty data such as Discord, PayPal or members in the island information and corrected the information about visitors count - it should show the number of visitors, just like the name says, but showed unique visitors (I made it show both counts)