### PR TITLE
Added raid trigger privilege

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/privilege/IslandPrivileges.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/privilege/IslandPrivileges.java
@@ -68,6 +68,8 @@ public class IslandPrivileges {
     @Nullable
     public static final IslandPrivilege PICKUP_LECTERN_BOOK = register("PICKUP_LECTERN_BOOK", ServerVersion.isAtLeast(ServerVersion.v1_14));
     public static final IslandPrivilege PROMOTE_MEMBERS = register("PROMOTE_MEMBERS", IslandPrivilege.Type.COMMAND);
+    @Nullable
+    public static final IslandPrivilege RAID_TRIGGER = register("RAID_TRIGGER", ServerVersion.isAtLeast(ServerVersion.v1_14));
     public static final IslandPrivilege RANKUP = register("RANKUP", IslandPrivilege.Type.COMMAND);
     public static final IslandPrivilege RATINGS_SHOW = register("RATINGS_SHOW", IslandPrivilege.Type.COMMAND);
     public static final IslandPrivilege SADDLE_ENTITY = register("SADDLE_ENTITY");

--- a/src/main/java/com/bgsoftware/superiorskyblock/listener/ProtectionListener.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/listener/ProtectionListener.java
@@ -559,15 +559,11 @@ public class ProtectionListener extends AbstractGameEventListener {
     /* WORLD EVENTS */
 
     private void onRaidTrigger(GameEvent<GameEventArgs.RaidTriggerEvent> e) {
-        if (!plugin.getGrid().isIslandsWorld(e.getArgs().world))
-            return;
-
         SuperiorPlayer superiorPlayer = plugin.getPlayers().getSuperiorPlayer(e.getArgs().player);
         Location raidLocation = e.getArgs().raidLocation;
 
-        Island island = plugin.getGrid().getIslandAt(raidLocation);
-
-        if (island == null || island.isSpawn() || !island.isInside(raidLocation) || !island.isMember(superiorPlayer))
+        InteractionResult interactionResult = this.protectionManager.get().handleCustomInteraction(superiorPlayer, raidLocation, IslandPrivileges.RAID_TRIGGER);
+        if (ProtectionHelper.shouldPreventInteraction(interactionResult, superiorPlayer, true))
             e.setCancelled();
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -255,6 +255,7 @@ island-roles:
         - FLY
         - ISLAND_CHEST
         - MONSTER_SPAWN
+        - RAID_TRIGGER
         - RANKUP
         - SPAWNER_BREAK
     mod:

--- a/src/main/resources/menus/permissions1_16.yml
+++ b/src/main/resources/menus/permissions1_16.yml
@@ -1738,6 +1738,39 @@ permissions:
         volume: 0.2
         pitch: 0.2
 
+  raid_trigger:
+    display-menu: true
+    permission-enabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &aENABLED&7.'
+    permission-disabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &cDISABLED&7.'
+    role-permission:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Role: &e{}&7.'
+        - ''
+        - '{0}'
+    has-access:
+      sound:
+        type: ENTITY_EXPERIENCE_ORB_PICKUP
+        volume: 0.2
+        pitch: 0.2
+    no-access:
+      sound:
+        type: BLOCK_ANVIL_PLACE
+        volume: 0.2
+        pitch: 0.2
+
   rankup:
     display-menu: true
     permission-enabled:

--- a/src/main/resources/menus/permissions1_17.yml
+++ b/src/main/resources/menus/permissions1_17.yml
@@ -1771,6 +1771,39 @@ permissions:
         volume: 0.2
         pitch: 0.2
 
+  raid_trigger:
+    display-menu: true
+    permission-enabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &aENABLED&7.'
+    permission-disabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &cDISABLED&7.'
+    role-permission:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Role: &e{}&7.'
+        - ''
+        - '{0}'
+    has-access:
+      sound:
+        type: ENTITY_EXPERIENCE_ORB_PICKUP
+        volume: 0.2
+        pitch: 0.2
+    no-access:
+      sound:
+        type: BLOCK_ANVIL_PLACE
+        volume: 0.2
+        pitch: 0.2
+
   rankup:
     display-menu: true
     permission-enabled:

--- a/src/main/resources/menus/permissions1_20.yml
+++ b/src/main/resources/menus/permissions1_20.yml
@@ -1804,6 +1804,39 @@ permissions:
         volume: 0.2
         pitch: 0.2
 
+  raid_trigger:
+    display-menu: true
+    permission-enabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &aENABLED&7.'
+    permission-disabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &cDISABLED&7.'
+    role-permission:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Role: &e{}&7.'
+        - ''
+        - '{0}'
+    has-access:
+      sound:
+        type: ENTITY_EXPERIENCE_ORB_PICKUP
+        volume: 0.2
+        pitch: 0.2
+    no-access:
+      sound:
+        type: BLOCK_ANVIL_PLACE
+        volume: 0.2
+        pitch: 0.2
+
   rankup:
     display-menu: true
     permission-enabled:

--- a/src/main/resources/menus/permissions1_21.yml
+++ b/src/main/resources/menus/permissions1_21.yml
@@ -1804,6 +1804,39 @@ permissions:
         volume: 0.2
         pitch: 0.2
 
+  raid_trigger:
+    display-menu: true
+    permission-enabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &aENABLED&7.'
+    permission-disabled:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Currently &cDISABLED&7.'
+    role-permission:
+      type: CROSSBOW
+      name: '&6Raid Trigger'
+      lore:
+        - '&7Access to trigger raids inside the island.'
+        - '&7Role: &e{}&7.'
+        - ''
+        - '{0}'
+    has-access:
+      sound:
+        type: ENTITY_EXPERIENCE_ORB_PICKUP
+        volume: 0.2
+        pitch: 0.2
+    no-access:
+      sound:
+        type: BLOCK_ANVIL_PLACE
+        volume: 0.2
+        pitch: 0.2
+
   rankup:
     display-menu: true
     permission-enabled:


### PR DESCRIPTION
Instead of allowing only island members to trigger raids, I added a privilege that allows you to choose which role can trigger raids, as suggested in this [Discussion](https://github.com/BG-Software-LLC/SuperiorSkyblock2/discussions/2610) (so after merging, close it)