### PR TITLE
Fixed breaking warp sign when deleting it

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/warp/SignWarp.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/warp/SignWarp.java
@@ -46,7 +46,7 @@ public class SignWarp {
 
             // Detected warp sign
             signBlock.setType(Material.AIR);
-            signBlock.getWorld().dropItemNaturally(warpLocation, new ItemStack(Material.SIGN));
+            signBlock.getWorld().dropItemNaturally(warpLocation, new ItemStack(blockState.getType()));
 
             Message.DELETE_WARP_SIGN_BROKE.send(commandSender);
         }


### PR DESCRIPTION
It always dropped the oak sign instead of the sign that was used to create that warp