### PR TITLE
Added home teleport and visitor home teleport events

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandHomeTeleportEvent.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandHomeTeleportEvent.java
@@ -1,44 +1,44 @@
 package com.bgsoftware.superiorskyblock.api.events;
 
 import com.bgsoftware.superiorskyblock.api.island.Island;
-import com.bgsoftware.superiorskyblock.api.island.warps.IslandWarp;
+import com.bgsoftware.superiorskyblock.api.world.Dimension;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import org.bukkit.event.Cancellable;
 
 /**
- * IslandWarpTeleportEvent is called when a player teleports to island warp.
+ * IslandWarpTeleportEvent is called when a player teleports to island home.
  */
-public class IslandWarpTeleportEvent extends IslandEvent implements Cancellable {
+public class IslandHomeTeleportEvent extends IslandEvent implements Cancellable {
 
     private final SuperiorPlayer superiorPlayer;
-    private final IslandWarp islandWarp;
+    private final Dimension dimension;
     private boolean cancelled = false;
 
     /**
      * The constructor of the event.
      *
      * @param island         The island that the player teleports to.
-     * @param superiorPlayer The player who teleports to the island warp.
-     * @param islandWarp     The island warp that the player teleports to.
+     * @param superiorPlayer The player who teleports to the island home.
+     * @param dimension      The dimension that the player teleports to.
      */
-    public IslandWarpTeleportEvent(Island island, SuperiorPlayer superiorPlayer, IslandWarp islandWarp) {
+    public IslandHomeTeleportEvent(Island island, SuperiorPlayer superiorPlayer, Dimension dimension) {
         super(island);
         this.superiorPlayer = superiorPlayer;
-        this.islandWarp = islandWarp;
+        this.dimension = dimension;
     }
 
     /**
-     * Get the player who teleports to the island warp.
+     * Get the player who teleports to the island home.
      */
     public SuperiorPlayer getPlayer() {
         return superiorPlayer;
     }
 
     /**
-     * Get the island warp that the player teleports to.
+     * Get the dimension that the player teleports to.
      */
-    public IslandWarp getIslandWarp() {
-        return this.islandWarp;
+    public Dimension getDimension() {
+        return this.dimension;
     }
 
     @Override

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandHomeTeleportEvent.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandHomeTeleportEvent.java
@@ -6,7 +6,7 @@ import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import org.bukkit.event.Cancellable;
 
 /**
- * IslandWarpTeleportEvent is called when a player teleports to island home.
+ * IslandHomeTeleportEvent is called when a player teleports to island home.
  */
 public class IslandHomeTeleportEvent extends IslandEvent implements Cancellable {
 

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandVisitorHomeTeleportEvent.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandVisitorHomeTeleportEvent.java
@@ -6,7 +6,7 @@ import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import org.bukkit.event.Cancellable;
 
 /**
- * IslandWarpTeleportEvent is called when a player teleports to island visitor home.
+ * IslandVisitorHomeTeleportEvent is called when a player teleports to island visitor home.
  */
 public class IslandVisitorHomeTeleportEvent extends IslandEvent implements Cancellable {
 

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandVisitorHomeTeleportEvent.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/events/IslandVisitorHomeTeleportEvent.java
@@ -1,44 +1,44 @@
 package com.bgsoftware.superiorskyblock.api.events;
 
 import com.bgsoftware.superiorskyblock.api.island.Island;
-import com.bgsoftware.superiorskyblock.api.island.warps.IslandWarp;
+import com.bgsoftware.superiorskyblock.api.world.Dimension;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import org.bukkit.event.Cancellable;
 
 /**
- * IslandWarpTeleportEvent is called when a player teleports to island warp.
+ * IslandWarpTeleportEvent is called when a player teleports to island visitor home.
  */
-public class IslandWarpTeleportEvent extends IslandEvent implements Cancellable {
+public class IslandVisitorHomeTeleportEvent extends IslandEvent implements Cancellable {
 
     private final SuperiorPlayer superiorPlayer;
-    private final IslandWarp islandWarp;
+    private final Dimension dimension;
     private boolean cancelled = false;
 
     /**
      * The constructor of the event.
      *
      * @param island         The island that the player teleports to.
-     * @param superiorPlayer The player who teleports to the island warp.
-     * @param islandWarp     The island warp that the player teleports to.
+     * @param superiorPlayer The player who teleports to the island visitor home.
+     * @param dimension      The dimension that the player teleports to.
      */
-    public IslandWarpTeleportEvent(Island island, SuperiorPlayer superiorPlayer, IslandWarp islandWarp) {
+    public IslandVisitorHomeTeleportEvent(Island island, SuperiorPlayer superiorPlayer, Dimension dimension) {
         super(island);
         this.superiorPlayer = superiorPlayer;
-        this.islandWarp = islandWarp;
+        this.dimension = dimension;
     }
 
     /**
-     * Get the player who teleports to the island warp.
+     * Get the player who teleports to the island visitor home.
      */
     public SuperiorPlayer getPlayer() {
         return superiorPlayer;
     }
 
     /**
-     * Get the island warp that the player teleports to.
+     * Get the dimension that the player teleports to.
      */
-    public IslandWarp getIslandWarp() {
-        return this.islandWarp;
+    public Dimension getDimension() {
+        return this.dimension;
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminTeleport.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminTeleport.java
@@ -10,7 +10,6 @@ import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.core.LazyReference;
-import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.PortalType;
 import org.bukkit.World;
@@ -99,9 +98,6 @@ public class CmdAdminTeleport implements IAdminIslandCommand {
                 return;
             }
         }
-
-        if (!PluginEventsFactory.callIslandHomeTeleportEvent(island, superiorPlayer, dimension))
-            return;
 
         superiorPlayer.teleport(island, dimension, result -> {
             if (!result) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminTeleport.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminTeleport.java
@@ -10,6 +10,7 @@ import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.core.LazyReference;
+import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.PortalType;
 import org.bukkit.World;
@@ -98,6 +99,9 @@ public class CmdAdminTeleport implements IAdminIslandCommand {
                 return;
             }
         }
+
+        if (!PluginEventsFactory.callIslandHomeTeleportEvent(island, superiorPlayer, dimension))
+            return;
 
         superiorPlayer.teleport(island, dimension, result -> {
             if (!result) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdTeleport.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdTeleport.java
@@ -2,10 +2,12 @@ package com.bgsoftware.superiorskyblock.commands.player;
 
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.island.Island;
+import com.bgsoftware.superiorskyblock.api.world.Dimension;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.ISuperiorCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.commands.arguments.IslandArgument;
+import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.world.EntityTeleports;
 import org.bukkit.command.CommandSender;
@@ -61,6 +63,10 @@ public class CmdTeleport implements ISuperiorCommand {
             return;
 
         SuperiorPlayer superiorPlayer = arguments.getSuperiorPlayer();
+        Dimension dimension = plugin.getSettings().getWorlds().getDefaultWorldDimension();
+
+        if (!PluginEventsFactory.callIslandHomeTeleportEvent(island, superiorPlayer, dimension))
+            return;
 
         EntityTeleports.warmupTeleport(superiorPlayer, plugin.getSettings().getHomeWarmup(),
                 unused -> teleportToIsland(superiorPlayer, island));

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdVisit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdVisit.java
@@ -73,9 +73,11 @@ public class CmdVisit implements ISuperiorCommand {
         SuperiorPlayer superiorPlayer = plugin.getPlayers().getSuperiorPlayer(sender);
         Dimension dimension = plugin.getSettings().getWorlds().getDefaultWorldDimension();
 
-        IslandWorlds.accessIslandWorldAsync(targetIsland, dimension, true, islandWorldResult -> {
-            islandWorldResult.ifLeft(world -> teleportPlayerInternal(targetIsland, superiorPlayer));
-        });
+        if (!PluginEventsFactory.callIslandVisitorHomeTeleportEvent(targetIsland, superiorPlayer, dimension))
+            return;
+
+        IslandWorlds.accessIslandWorldAsync(targetIsland, dimension, true, islandWorldResult ->
+                islandWorldResult.ifLeft(world -> teleportPlayerInternal(targetIsland, superiorPlayer)));
     }
 
     @Override
@@ -119,10 +121,9 @@ public class CmdVisit implements ISuperiorCommand {
 
         Location finalVisitLocation = visitLocation;
 
-        EntityTeleports.warmupTeleport(superiorPlayer, plugin.getSettings().getVisitWarmup(), afterWarmup -> {
-            teleportPlayerNoWarmup(superiorPlayer, targetIsland, finalVisitLocation, isVisitorSign,
-                    afterWarmup /*checkIslandLock*/, true);
-        });
+        EntityTeleports.warmupTeleport(superiorPlayer, plugin.getSettings().getVisitWarmup(), afterWarmup ->
+                teleportPlayerNoWarmup(superiorPlayer, targetIsland, finalVisitLocation,
+                        isVisitorSign, afterWarmup /*checkIslandLock*/, true));
     }
 
     private static void teleportPlayerNoWarmup(SuperiorPlayer superiorPlayer, Island island, Location visitLocation,

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/events/args/PluginEventArgs.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/events/args/PluginEventArgs.java
@@ -371,6 +371,12 @@ public class PluginEventArgs {
 
     }
 
+    public static class IslandHomeTeleport extends IslandDoActionArgs {
+
+        public Dimension dimension;
+
+    }
+
     public static class IslandInvite extends IslandDoActionArgs {
 
         public SuperiorPlayer targetPlayer;
@@ -542,6 +548,12 @@ public class PluginEventArgs {
         public List<String> commands;
         public IslandUpgradeEvent.Cause upgradeCause;
         public UpgradeCost upgradeCost;
+
+    }
+
+    public static class IslandVisitorHomeTeleport extends IslandDoActionArgs {
+
+        public Dimension dimension;
 
     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/events/plugin/PluginEventType.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/events/plugin/PluginEventType.java
@@ -53,6 +53,7 @@ import com.bgsoftware.superiorskyblock.api.events.IslandEnterEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandEnterPortalEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandEnterProtectedEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandGenerateBlockEvent;
+import com.bgsoftware.superiorskyblock.api.events.IslandHomeTeleportEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandInviteEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandJoinEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandKickEvent;
@@ -82,6 +83,7 @@ import com.bgsoftware.superiorskyblock.api.events.IslandUnbanEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandUncoopPlayerEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandUnlockWorldEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandUpgradeEvent;
+import com.bgsoftware.superiorskyblock.api.events.IslandVisitorHomeTeleportEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandWarpTeleportEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandWorldResetEvent;
 import com.bgsoftware.superiorskyblock.api.events.IslandWorthCalculatedEvent;
@@ -172,6 +174,7 @@ import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.I
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandEnterPortal;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandEnterProtected;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandGenerateBlock;
+import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandHomeTeleport;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandInvite;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandJoin;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandKick;
@@ -201,6 +204,7 @@ import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.I
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandUncoopPlayer;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandUnlockWorld;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandUpgrade;
+import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandVisitorHomeTeleport;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandWarpTeleport;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandWorldReset;
 import static com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs.IslandWorthCalculated;
@@ -761,6 +765,12 @@ public abstract class PluginEventType<Args extends PluginEventArgs> extends Even
             pluginEvent.getArgs().placeBlock = ((IslandGenerateBlockEvent) bukkitEvent).isPlaceBlock();
         }
     };
+    public static final PluginEventType<IslandHomeTeleport> ISLAND_HOME_TELEPORT_EVENT = new PluginEventType<IslandHomeTeleport>(IslandHomeTeleportEvent.class) {
+        @Override
+        public Event createBukkitEvent(IslandHomeTeleport args) {
+            return new IslandHomeTeleportEvent(args.island, args.superiorPlayer, args.dimension);
+        }
+    };
     public static final PluginEventType<IslandInvite> ISLAND_INVITE_EVENT = new PluginEventType<IslandInvite>(IslandInviteEvent.class) {
         @Override
         public Event createBukkitEvent(IslandInvite args) {
@@ -983,7 +993,13 @@ public abstract class PluginEventType<Args extends PluginEventArgs> extends Even
             pluginEvent.getArgs().upgradeCost = ((IslandUpgradeEvent) bukkitEvent).getUpgradeCost();
         }
     };
-    public static final PluginEventType<IslandWarpTeleport> ISLAND_WARP_TELEPORT_EVENT = new PluginEventType<IslandWarpTeleport>(IslandUpgradeEvent.class) {
+    public static final PluginEventType<IslandVisitorHomeTeleport> ISLAND_VISITOR_HOME_TELEPORT_EVENT = new PluginEventType<IslandVisitorHomeTeleport>(IslandVisitorHomeTeleportEvent.class) {
+        @Override
+        public Event createBukkitEvent(IslandVisitorHomeTeleport args) {
+            return new IslandVisitorHomeTeleportEvent(args.island, args.superiorPlayer, args.dimension);
+        }
+    };
+    public static final PluginEventType<IslandWarpTeleport> ISLAND_WARP_TELEPORT_EVENT = new PluginEventType<IslandWarpTeleport>(IslandWarpTeleportEvent.class) {
         @Override
         public Event createBukkitEvent(IslandWarpTeleport args) {
             return new IslandWarpTeleportEvent(args.island, args.superiorPlayer, args.islandWarp);

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/events/plugin/PluginEventsFactory.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/events/plugin/PluginEventsFactory.java
@@ -628,6 +628,14 @@ public class PluginEventsFactory {
         return fireEvent(ISLAND_GENERATE_BLOCK_EVENT, islandGenerateBlock);
     }
 
+    public static boolean callIslandHomeTeleportEvent(Island island, SuperiorPlayer superiorPlayer, Dimension dimension) {
+        IslandHomeTeleport islandHomeTeleport = new IslandHomeTeleport();
+        islandHomeTeleport.island = island;
+        islandHomeTeleport.superiorPlayer = superiorPlayer;
+        islandHomeTeleport.dimension = dimension;
+        return !fireEvent(ISLAND_HOME_TELEPORT_EVENT, islandHomeTeleport).isCancelled();
+    }
+
     public static boolean callIslandInviteEvent(Island island, SuperiorPlayer superiorPlayer, SuperiorPlayer targetPlayer) {
         IslandInvite islandInvite = new IslandInvite();
         islandInvite.island = island;
@@ -946,6 +954,14 @@ public class PluginEventsFactory {
         islandUpgrade.upgradeCause = upgradeCause;
         islandUpgrade.upgradeCost = upgradeCost;
         return fireEvent(ISLAND_UPGRADE_EVENT, islandUpgrade);
+    }
+
+    public static boolean callIslandVisitorHomeTeleportEvent(Island island, SuperiorPlayer superiorPlayer, Dimension dimension) {
+        IslandVisitorHomeTeleport islandVisitorHomeTeleport = new IslandVisitorHomeTeleport();
+        islandVisitorHomeTeleport.island = island;
+        islandVisitorHomeTeleport.superiorPlayer = superiorPlayer;
+        islandVisitorHomeTeleport.dimension = dimension;
+        return !fireEvent(ISLAND_VISITOR_HOME_TELEPORT_EVENT, islandVisitorHomeTeleport).isCancelled();
     }
 
     public static boolean callIslandWarpTeleportEvent(Island island, SuperiorPlayer superiorPlayer, IslandWarp islandWarp) {


### PR DESCRIPTION
# Changelog # 
- Added the IslandHomeTeleport event, which is called when using the /is tp command.
- Added the IslandVisitorHomeTeleport event, which is called when using the /is visit command.
- Changed the class used by the IslandWarpTeleport event, because it used the IslandUpgradeEvent class.
- Fixed the description of the constructor and getPlayer() method of the IslandWarpTeleport event.