### PR TITLE
Fixed tab completes in team admin commands

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandTabCompletes.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandTabCompletes.java
@@ -72,6 +72,12 @@ public class CommandTabCompletes {
         return getPlayers(island.getIslandMembers(false), argument);
     }
 
+    public static List<String> getOnlinePlayersWithIsland(SuperiorSkyblockPlugin plugin, String argument, boolean hideVanished,
+                                                          Predicate<SuperiorPlayer> predicate) {
+        return getOnlinePlayers(plugin, argument, hideVanished, (onlinePlayer) ->
+                onlinePlayer != null && onlinePlayer.hasIsland() && predicate.test(onlinePlayer));
+    }
+
     public static List<String> getOnlinePlayers(SuperiorSkyblockPlugin plugin, String argument, boolean hideVanish) {
         String lowerArgument = argument.toLowerCase(Locale.ENGLISH);
         return new SequentialListBuilder<SuperiorPlayer>()

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminDemote.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminDemote.java
@@ -4,6 +4,7 @@ import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.island.PlayerRole;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminPlayerCommand;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
@@ -90,6 +91,13 @@ public class CmdAdminDemote implements IAdminPlayerCommand {
 
         Message.DEMOTED_MEMBER.send(sender, targetPlayer.getName(), targetPlayer.getPlayerRole());
         Message.GOT_DEMOTED.send(targetPlayer, targetPlayer.getPlayerRole());
+    }
+
+    @Override
+    public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
+        return args.length == 3 ? CommandTabCompletes.getOnlinePlayersWithIsland(plugin, args[2], false,
+                superiorPlayer -> !superiorPlayer.getIslandLeader().equals(superiorPlayer) &&
+                        !superiorPlayer.getPlayerRole().isFirstRole()) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminKick.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminKick.java
@@ -1,10 +1,11 @@
 package com.bgsoftware.superiorskyblock.commands.admin;
 
-import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminPlayerCommand;
+import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.island.IslandUtils;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -70,6 +71,13 @@ public class CmdAdminKick implements IAdminPlayerCommand {
 
         IslandUtils.handleKickPlayer(sender instanceof Player ? plugin.getPlayers().getSuperiorPlayer(sender) : null,
                 sender.getName(), targetIsland, targetPlayer);
+    }
+
+    @Override
+    public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
+        return args.length == 3 ? CommandTabCompletes.getOnlinePlayersWithIsland(plugin, args[2], false,
+                superiorPlayer -> !superiorPlayer.getIslandLeader().equals(superiorPlayer)) :
+                Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminPromote.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminPromote.java
@@ -4,6 +4,7 @@ import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.island.PlayerRole;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminPlayerCommand;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
@@ -97,6 +98,13 @@ public class CmdAdminPromote implements IAdminPlayerCommand {
 
         Message.PROMOTED_MEMBER.send(sender, targetPlayer.getName(), targetPlayer.getPlayerRole());
         Message.GOT_PROMOTED.send(targetPlayer, targetPlayer.getPlayerRole());
+    }
+
+    @Override
+    public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
+        return args.length == 3 ? CommandTabCompletes.getOnlinePlayersWithIsland(plugin, args[2], false,
+                superiorPlayer -> !superiorPlayer.getIslandLeader().equals(superiorPlayer) &&
+                        !superiorPlayer.getPlayerRole().getNextRole().isLastRole()) : Collections.emptyList();
     }
 
 }


### PR DESCRIPTION
# Changelog # 
- The `/is admin demote` command displayed all players in the tab completes, instead of those who have an island, are not its leader and do not have the first role.
- The `/is admin kick` command displayed all players in the tab completes, instead of those who have an island and are not its leader.
- The `/is admin promote` command displayed all players in the tab completes, instead of those who have an island, are not its leader and do not have the last role.