### PR TITLE
Fixed tab completes in /is ban command

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdBan.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdBan.java
@@ -80,9 +80,9 @@ public class CmdBan implements IPermissibleCommand {
 
     @Override
     public List<String> tabComplete(SuperiorSkyblockPlugin plugin, SuperiorPlayer superiorPlayer, Island island, String[] args) {
-        return args.length != 2 ? Collections.emptyList() : CommandTabCompletes.getOnlinePlayers(plugin, args[1], true,
+        return args.length == 2 ? CommandTabCompletes.getOnlinePlayers(plugin, args[1], plugin.getSettings().isTabCompleteHideVanished(),
                 onlinePlayer -> !island.isBanned(onlinePlayer) && (!island.isMember(onlinePlayer) ||
-                        onlinePlayer.getPlayerRole().isLessThan(superiorPlayer.getPlayerRole())));
+                        onlinePlayer.getPlayerRole().isLessThan(superiorPlayer.getPlayerRole()))) : Collections.emptyList();
     }
 
 }


### PR DESCRIPTION
This command always hid vanished players in the tab completes instead of respecting the option from the config.