### PR TITLE
Fixed tab completes of /is admin data command

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminData.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminData.java
@@ -110,9 +110,12 @@ public class CmdAdminData implements ISuperiorCommand {
             }
             case 5: {
                 SubCommand subCommand = subCommands.get(args[2].toLowerCase(Locale.ENGLISH));
-                return subCommand == null ? Collections.emptyList() : args[3].equalsIgnoreCase("island") ?
-                        CommandTabCompletes.getOnlinePlayersAndIslands(plugin, args[4], false, null) :
-                        CommandTabCompletes.getOnlinePlayers(plugin, args[4], false);
+                if (subCommand != null && args[3].equalsIgnoreCase("island"))
+                    return CommandTabCompletes.getOnlinePlayersAndIslands(plugin, args[4], false, null);
+                else if (subCommand != null && args[3].equalsIgnoreCase("player"))
+                    CommandTabCompletes.getOnlinePlayers(plugin, args[4], false);
+                else
+                    return Collections.emptyList();
             }
             default: {
                 return Collections.emptyList();


### PR DESCRIPTION
The command displayed player names in the completes tab when the <player/island> argument was invalid