### PR TITLE
Fixed tab completes of /is admin close and /is admin open commands

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminClose.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminClose.java
@@ -4,12 +4,14 @@ import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class CmdAdminClose implements IAdminIslandCommand {
@@ -65,6 +67,12 @@ public class CmdAdminClose implements IAdminIslandCommand {
             island.setLocked(true);
             Message.ISLAND_CLOSED.send(sender);
         }
+    }
+
+    @Override
+    public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
+        return args.length == 3 ? CommandTabCompletes.getOnlinePlayersAndIslands(plugin, args[2], false,
+                (superiorPlayer, island) -> !island.isLocked()) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminOpen.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminOpen.java
@@ -4,12 +4,14 @@ import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
+import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class CmdAdminOpen implements IAdminIslandCommand {
@@ -64,6 +66,12 @@ public class CmdAdminOpen implements IAdminIslandCommand {
             island.setLocked(false);
             Message.ISLAND_OPENED.send(sender);
         }
+    }
+
+    @Override
+    public List<String> tabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, String[] args) {
+        return args.length == 3 ? CommandTabCompletes.getOnlinePlayersAndIslands(plugin, args[2], false,
+                (superiorPlayer, island) -> island.isLocked()) : Collections.emptyList();
     }
 
 }


### PR DESCRIPTION
Commands showed islands in tab completes that were already closed/opened, but they couldn't be closed/opened again.