### PR TITLE
Renamed level formula option

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -78,9 +78,9 @@ public interface SettingsManager {
     StackedBlocks getStackedBlocks();
 
     /**
-     * The island worth to island level conversion formula.
-     * The formula contains a placeholder: `{}`, which is replaced with the island worth.
-     * Config path: island-level-formula
+     * The formula used to calculate a block's level when it has a worth defined but no level specified.
+     * The formula can contain a placeholder: `{}`, which is replaced with the block worth.
+     * Config path: block-level-formula
      */
     String getIslandLevelFormula();
 

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -3,7 +3,6 @@ package com.bgsoftware.superiorskyblock.api.config;
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.api.enums.TopIslandMembersSorting;
 import com.bgsoftware.superiorskyblock.api.handlers.BlockValuesManager;
-import com.bgsoftware.superiorskyblock.api.island.SortingType;
 import com.bgsoftware.superiorskyblock.api.key.Key;
 import com.bgsoftware.superiorskyblock.api.key.KeySet;
 import com.bgsoftware.superiorskyblock.api.objects.Pair;

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -103,7 +103,7 @@ public class SettingsContainer {
     public final boolean stackedBlocksAutoPickup;
     public final boolean stackedBlocksMenuEnabled;
     public final String stackedBlocksMenuTitle;
-    public final String islandLevelFormula;
+    public final String blockLevelFormula;
     public final boolean roundedIslandLevel;
     public final RoundingMode islandLevelRoundingMode;
     public final boolean autoBlocksTracking;
@@ -306,7 +306,7 @@ public class SettingsContainer {
         stackedBlocksAutoPickup = config.getBoolean("stacked-blocks.auto-collect", false);
         stackedBlocksMenuEnabled = config.getBoolean("stacked-blocks.deposit-menu.enabled", true);
         stackedBlocksMenuTitle = Formatters.COLOR_FORMATTER.format(config.getString("stacked-blocks.deposit-menu.title", "&lDeposit Blocks"));
-        islandLevelFormula = config.getString("island-level-formula", "{} / 2");
+        blockLevelFormula = config.getString("block-level-formula", "{} / 2");
         roundedIslandLevel = config.getBoolean("rounded-island-level", false);
         islandLevelRoundingMode = Optional.ofNullable(EnumHelper.getEnum(RoundingMode.class,
                         config.getString("island-level-rounding-mode").toUpperCase(Locale.ENGLISH)))

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -5,7 +5,6 @@ import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.config.SettingsManager;
 import com.bgsoftware.superiorskyblock.api.enums.TopIslandMembersSorting;
 import com.bgsoftware.superiorskyblock.api.handlers.BlockValuesManager;
-import com.bgsoftware.superiorskyblock.api.island.SortingType;
 import com.bgsoftware.superiorskyblock.api.key.Key;
 import com.bgsoftware.superiorskyblock.api.key.KeySet;
 import com.bgsoftware.superiorskyblock.api.objects.Pair;
@@ -29,7 +28,6 @@ import com.bgsoftware.superiorskyblock.core.Manager;
 import com.bgsoftware.superiorskyblock.core.errors.ManagerLoadException;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.logging.Log;
-import com.bgsoftware.superiorskyblock.island.top.SortingComparators;
 import com.bgsoftware.superiorskyblock.player.inventory.ClearActions;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -137,7 +135,7 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
 
     @Override
     public String getIslandLevelFormula() {
-        return this.global.getIslandLevelFormula();
+        return this.global.getBlockLevelFormula();
     }
 
     @Override
@@ -724,6 +722,10 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     private void convertData(YamlConfiguration cfg) {
+        if (cfg.get("island-level-formula") != null) {
+            cfg.set("block-level-formula", cfg.getString("island-level-formula"));
+            cfg.set("island-level-formula", null);
+        }
         if (!cfg.isConfigurationSection("entity-categories")) {
             cfg.createSection("entity-categories");
         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
@@ -39,8 +39,8 @@ public class GlobalSection extends SettingsContainerHolder {
         return getContainer().worldBordersEnabled;
     }
 
-    public String getIslandLevelFormula() {
-        return getContainer().islandLevelFormula;
+    public String getBlockLevelFormula() {
+        return getContainer().blockLevelFormula;
     }
 
     public boolean isRoundedIslandLevels() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -151,11 +151,9 @@ stacked-blocks:
     # The title of the menu.
     title: '&lDeposit Blocks'
 
-# Set a formula to calculate the island level by it's worth.
+# The formula used to calculate a block's level when it has a worth defined but no level specified.
 # Use {} as a placeholder for worth. Make sure you only use digits and mathematical operations!
-# If you use Java 15 or above (Minecraft 1.16+), check out this page:
-# https://wiki.bg-software.com/superiorskyblock/new-java-engine
-island-level-formula: '{} / 2'
+block-level-formula: '{} / 2'
 
 # Should the island levels be a rounded integer?
 rounded-island-level: false


### PR DESCRIPTION
1. I changed the name of the `island-level-formula` option to `block-level-formula` because the old name was misleading; the formula is used to calculate the block level, not the island level. I only kept the old name in the API, as it's not a significant change.
2. I removed the script engine installation information from the description of this option, because according to that link, this process happens automatically anyway.
3. In SettingsManagerImpl, I didn't use isString() in convertData() because {} prevented it from being considered a String. The ability to use only numbers also created this problem, and you didn't want to use contains(), so I used get() and compared it to null.