### PR TITLE
Added the ability to modify default command aliases

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -603,6 +603,14 @@ public interface SettingsManager {
     IslandChests getIslandChests();
 
     /**
+     * Whether command-aliases should override the default command aliases or not.
+     * When true, the default aliases will not work and the command names in their
+     * usage will be replaced with the first alias added - will be the new label.
+     * Config-path: override-default-aliases
+     */
+    boolean isOverrideDefaultAliases();
+
+    /**
      * Custom aliases for commands of the plugin.
      * Represented by a map with keys as commands, and values as aliases.
      * Config-path: command-aliases

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandsHelper.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/CommandsHelper.java
@@ -1,10 +1,20 @@
 package com.bgsoftware.superiorskyblock.commands;
 
+import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.commands.SuperiorCommand;
 import com.bgsoftware.superiorskyblock.core.Text;
 import org.bukkit.command.CommandSender;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
 public class CommandsHelper {
+
+    private static final SuperiorSkyblockPlugin plugin = SuperiorSkyblockPlugin.getPlugin();
 
     private CommandsHelper() {
 
@@ -17,6 +27,58 @@ public class CommandsHelper {
     public static boolean hasCommandAccess(SuperiorCommand superiorCommand, CommandSender executor) {
         String permission = superiorCommand.getPermission();
         return Text.isBlank(permission) || executor.hasPermission(permission);
+    }
+
+    public static String getCommandUsage(SuperiorCommand superiorCommand, Locale locale) {
+        String pluginLabel = plugin.getCommands().getLabel() + " ";
+
+        if (!plugin.getSettings().isOverrideDefaultAliases())
+            return pluginLabel + superiorCommand.getUsage(locale);
+
+        String usage = superiorCommand.getUsage(locale);
+        String defaultLabel = superiorCommand.getAliases().get(0);
+
+        if (usage.startsWith(defaultLabel))
+            return pluginLabel + usage.replaceFirst(defaultLabel, getCommandLabel(superiorCommand));
+
+        SuperiorCommand cmdAdmin = plugin.getCommands().getCommand("admin");
+        String defaultAdminLabel = cmdAdmin.getAliases().get(0);
+
+        if (usage.startsWith(defaultAdminLabel)) {
+            usage = usage.substring(defaultAdminLabel.length() + 1);
+
+            if (usage.startsWith(defaultLabel))
+                usage = usage.replaceFirst(defaultLabel, getCommandLabel(superiorCommand));
+
+            return pluginLabel + getCommandLabel(cmdAdmin) + " " + usage;
+        }
+
+        return pluginLabel + usage;
+    }
+
+    public static String getCommandLabel(SuperiorCommand superiorCommand) {
+        if (!plugin.getSettings().isOverrideDefaultAliases())
+            return superiorCommand.getAliases().get(0);
+
+        return getCommandAliases(superiorCommand).get(0);
+    }
+
+    public static List<String> getCommandAliases(SuperiorCommand superiorCommand) {
+        List<String> defaultAliases = new ArrayList<>(superiorCommand.getAliases());
+        List<String> customAliases = new ArrayList<>();
+
+        for (String alias : defaultAliases) {
+            List<String> aliases = plugin.getSettings().getCommandAliases().getOrDefault(alias, Collections.emptyList());
+            customAliases.addAll(aliases);
+        }
+
+        if (!customAliases.isEmpty() && plugin.getSettings().isOverrideDefaultAliases())
+            return customAliases;
+
+        Set<String> combinedAliases = new LinkedHashSet<>(defaultAliases);
+        combinedAliases.addAll(customAliases);
+
+        return new ArrayList<>(combinedAliases);
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAddBonus.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAddBonus.java
@@ -7,6 +7,7 @@ import com.bgsoftware.superiorskyblock.api.events.IslandChangeWorthBonusEvent;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs;
@@ -77,7 +78,7 @@ public class CmdAdminAddBonus implements IAdminIslandCommand {
             isWorthBonus = false;
         } else {
             Locale locale = PlayerLocales.getLocale(sender);
-            Message.COMMAND_USAGE.send(sender, locale, plugin.getCommands().getLabel() + " " + getUsage(locale));
+            Message.COMMAND_USAGE.send(sender, locale, CommandsHelper.getCommandUsage(this, locale));
             return;
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminData.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminData.java
@@ -6,6 +6,7 @@ import com.bgsoftware.superiorskyblock.api.persistence.IPersistentDataHolder;
 import com.bgsoftware.superiorskyblock.api.persistence.PersistentDataContainer;
 import com.bgsoftware.superiorskyblock.api.persistence.PersistentDataType;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.ISuperiorCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.commands.arguments.IslandArgument;
@@ -71,13 +72,13 @@ public class CmdAdminData implements ISuperiorCommand {
         SubCommand subCommand = subCommands.get(args[2].toLowerCase(Locale.ENGLISH));
 
         if (subCommand == null) {
-            Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(PlayerLocales.getLocale(sender)));
+            Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, PlayerLocales.getLocale(sender)));
             return;
         }
 
         if (args.length < subCommand.getMinArgs() || args.length > subCommand.getMaxArgs()) {
             Locale senderLocale = PlayerLocales.getLocale(sender);
-            Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(senderLocale) + subCommand.getUsage(senderLocale));
+            Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, senderLocale) + subCommand.getUsage(senderLocale));
             return;
         }
 
@@ -90,7 +91,7 @@ public class CmdAdminData implements ISuperiorCommand {
             persistentDataHolder = CommandArguments.getPlayer(plugin, sender, args[4]);
         } else {
             Locale senderLocale = PlayerLocales.getLocale(sender);
-            Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(senderLocale) + subCommand.getUsage(senderLocale));
+            Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, senderLocale) + subCommand.getUsage(senderLocale));
             return;
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminDebug.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminDebug.java
@@ -2,6 +2,7 @@ package com.bgsoftware.superiorskyblock.commands.admin;
 
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.ISuperiorCommand;
 import com.bgsoftware.superiorskyblock.core.EnumHelper;
 import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
@@ -66,7 +67,7 @@ public class CmdAdminDebug implements ISuperiorCommand {
             if (originalDebugMode) {
                 debugFilter = null;
             } else {
-                Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(PlayerLocales.getLocale(sender)));
+                Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, PlayerLocales.getLocale(sender)));
                 return;
             }
         } else {

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminModules.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminModules.java
@@ -3,6 +3,7 @@ package com.bgsoftware.superiorskyblock.commands.admin;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.modules.PluginModule;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.ISuperiorCommand;
 import com.bgsoftware.superiorskyblock.core.logging.Log;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
@@ -115,7 +116,7 @@ public class CmdAdminModules implements ISuperiorCommand {
                         Message.MODULE_UNLOADED_SUCCESS.send(sender);
                         break;
                     default:
-                        Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(PlayerLocales.getLocale(sender)));
+                        Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, PlayerLocales.getLocale(sender)));
                         break;
                 }
             }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminSetBonus.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminSetBonus.java
@@ -7,6 +7,7 @@ import com.bgsoftware.superiorskyblock.api.events.IslandChangeWorthBonusEvent;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs;
@@ -78,7 +79,7 @@ public class CmdAdminSetBonus implements IAdminIslandCommand {
             isWorthBonus = false;
         } else {
             Locale locale = PlayerLocales.getLocale(sender);
-            Message.COMMAND_USAGE.send(sender, locale, plugin.getCommands().getLabel() + " " + getUsage(locale));
+            Message.COMMAND_USAGE.send(sender, locale, CommandsHelper.getCommandUsage(this, locale));
             return;
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAdmin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAdmin.java
@@ -90,8 +90,9 @@ public class CmdAdmin implements ISuperiorCommand {
                 }
 
                 if (args.length < command.getMinArgs() || args.length > command.getMaxArgs()) {
-                    Log.debugResult(Debug.EXECUTE_COMMAND, "Return Incorrect Usage", command.getUsage(locale));
-                    Message.COMMAND_USAGE.send(sender, locale, plugin.getCommands().getLabel() + " " + command.getUsage(locale));
+                    String usage = CommandsHelper.getCommandUsage(command, locale);
+                    Log.debugResult(Debug.EXECUTE_COMMAND, "Return Incorrect Usage", usage);
+                    Message.COMMAND_USAGE.send(sender, locale, usage);
                     return;
                 }
 
@@ -157,7 +158,7 @@ public class CmdAdmin implements ISuperiorCommand {
             String description = subCommand.getDescription(locale);
             if (description == null)
                 new NullPointerException("The description of the command " + subCommand.getAliases().get(0) + " is null.").printStackTrace();
-            Message.ADMIN_HELP_LINE.send(sender, locale, plugin.getCommands().getLabel() + " " + subCommand.getUsage(locale), description);
+            Message.ADMIN_HELP_LINE.send(sender, locale, CommandsHelper.getCommandUsage(subCommand, locale), description);
         }
 
         if (page != lastPage)
@@ -182,8 +183,7 @@ public class CmdAdmin implements ISuperiorCommand {
 
         for (SuperiorCommand subCommand : plugin.getCommands().getAdminSubCommands()) {
             if (CommandsHelper.shouldDisplayCommandForPlayer(subCommand, sender)) {
-                List<String> aliases = new LinkedList<>(subCommand.getAliases());
-                aliases.addAll(plugin.getSettings().getCommandAliases().getOrDefault(aliases.get(0).toLowerCase(Locale.ENGLISH), Collections.emptyList()));
+                List<String> aliases = new LinkedList<>(CommandsHelper.getCommandAliases(subCommand));
                 for (String alias : aliases) {
                     if (alias.contains(args[1].toLowerCase(Locale.ENGLISH))) {
                         list.add(alias);

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdHelp.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdHelp.java
@@ -126,7 +126,7 @@ public class CmdHelp implements ISuperiorCommand {
             String description = subCommand.getDescription(locale);
             if (description == null)
                 new NullPointerException("The description of the command " + subCommand.getAliases().get(0) + " is null.").printStackTrace();
-            Message.ISLAND_HELP_LINE.send(sender, plugin.getCommands().getLabel() + " " + subCommand.getUsage(locale), description == null ? "" : description);
+            Message.ISLAND_HELP_LINE.send(sender, CommandsHelper.getCommandUsage(subCommand, locale), description == null ? "" : description);
         }
 
         if (page != lastPage)

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -210,6 +210,7 @@ public class SettingsContainer {
     public final String islandChestTitle;
     public final int islandChestsDefaultPage;
     public final int islandChestsDefaultSize;
+    public final boolean overrideDefaultAliases;
     public final Map<String, List<String>> commandAliases;
     public final KeySet valuableBlocks;
     public final GameMode islandPreviewsGameMode;
@@ -545,6 +546,7 @@ public class SettingsContainer {
         islandChestTitle = Formatters.COLOR_FORMATTER.format(config.getString("island-chests.chest-title", "&4Island Chest"));
         islandChestsDefaultPage = config.getInt("island-chests.default-pages", 0);
         islandChestsDefaultSize = Math.min(6, Math.max(1, config.getInt("island-chests.default-size", 3)));
+        overrideDefaultAliases = config.getBoolean("override-default-aliases", false);
         Map<String, List<String>> commandAliases = new HashMap<>();
         if (config.isConfigurationSection("command-aliases")) {
             for (String label : config.getConfigurationSection("command-aliases").getKeys(false)) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -558,6 +558,11 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     @Override
+    public boolean isOverrideDefaultAliases() {
+        return this.global.isOverrideDefaultAliases();
+    }
+
+    @Override
     public Map<String, List<String>> getCommandAliases() {
         return this.global.getCommandAliases();
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
@@ -331,6 +331,10 @@ public class GlobalSection extends SettingsContainerHolder {
         return getContainer().schematicNameArgument;
     }
 
+    public boolean isOverrideDefaultAliases() {
+        return getContainer().overrideDefaultAliases;
+    }
+
     public Map<String, List<String>> getCommandAliases() {
         return getContainer().commandAliases;
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/missions/commands/CmdAdminMission.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/missions/commands/CmdAdminMission.java
@@ -6,6 +6,7 @@ import com.bgsoftware.superiorskyblock.api.missions.IMissionsHolder;
 import com.bgsoftware.superiorskyblock.api.missions.Mission;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.IAdminPlayerCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
@@ -99,7 +100,7 @@ public class CmdAdminMission implements IAdminPlayerCommand {
             return;
         }
 
-        Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(PlayerLocales.getLocale(sender)));
+        Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, PlayerLocales.getLocale(sender)));
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/missions/commands/CmdMission.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/missions/commands/CmdMission.java
@@ -4,6 +4,7 @@ import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.missions.Mission;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
+import com.bgsoftware.superiorskyblock.commands.CommandsHelper;
 import com.bgsoftware.superiorskyblock.commands.ISuperiorCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
@@ -58,7 +59,7 @@ public class CmdMission implements ISuperiorCommand {
 
         if (!args[1].equalsIgnoreCase("complete")) {
             Locale locale = PlayerLocales.getLocale(sender);
-            Message.COMMAND_USAGE.send(sender, plugin.getCommands().getLabel() + " " + getUsage(locale));
+            Message.COMMAND_USAGE.send(sender, CommandsHelper.getCommandUsage(this, locale));
             return;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -811,11 +811,18 @@ island-chests:
   # This number must be between 1 and 6.
   default-size: 3
 
+# Should custom aliases for plugin's commands override the default aliases?
+# When true, default aliases will be disabled, and the plugin will attempt to replace
+# default command labels in command usage messages with the first custom alias.
+override-default-aliases: false
+
 # Custom aliases for plugin's commands.
-command-aliases:
-  example-command:
-    - 'Aliase1'
-    - 'Aliase2'
+# The following example will add '/is gui' and '/is menu' as aliases for the '/is panel' command:
+# command-aliases:
+#   panel:
+#   - gui
+#   - menu
+command-aliases: [ ]
 
 # A list of valuable blocks.
 # These blocks require the "VALUABLE_BREAK" permission in order to break them.


### PR DESCRIPTION
I've introduced an option that lets you toggle whether we want to use the default command aliases or only those set as command-aliases.

I've tried implementing this several times, but something always went wrong. Only after you added the CommandsMap.clearCommands() method today did I finally succeed. I know it might not be perfect, so please review it carefully and tell me what to modify to improve performance.

I've included the ability to modify aliases while the server is running, so for example, I've modified CommandsManagerImpl.commandsCooldown to store SuperiorCommand instead of String.

Unfortunately, the usage of commands also stores labels, so it's a bit of a hassle to modify them in CommandsHelper, but everything works fine.

Let me know what you think @OmerBenGera , this option will definitely be useful to many people, so it would be good if it could be merged after any fixes 😃