### PR TITLE
Improved disabling the upgrades module

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/AdminCommandsMap.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/AdminCommandsMap.java
@@ -14,12 +14,10 @@ public class AdminCommandsMap extends CommandsMap {
         clearCommands();
 
         registerCommand(new CmdAdminAdd());
-        registerCommand(new CmdAdminAddBlockLimit());
         registerCommand(new CmdAdminAddBonus());
         if (plugin.getSettings().isCoopMembers())
             registerCommand(new CmdAdminAddCoopLimit());
         registerCommand(new CmdAdminAddDisbands());
-        registerCommand(new CmdAdminAddEntityLimit());
         registerCommand(new CmdAdminAddSize());
         registerCommand(new CmdAdminAddTeamLimit());
         registerCommand(new CmdAdminAddWarpsLimit());
@@ -47,8 +45,6 @@ public class AdminCommandsMap extends CommandsMap {
         registerCommand(new CmdAdminPurge());
         registerCommand(new CmdAdminRecalc());
         registerCommand(new CmdAdminReload());
-        registerCommand(new CmdAdminRemoveBlockLimit());
-        registerCommand(new CmdAdminRemoveEntityLimit());
         registerCommand(new CmdAdminRemoveRatings());
         registerCommand(new CmdAdminResetPermissions());
         registerCommand(new CmdAdminResetSettings());
@@ -57,13 +53,11 @@ public class AdminCommandsMap extends CommandsMap {
         registerCommand(new CmdAdminSetBankLimit());
         registerCommand(new CmdAdminSetBiome());
         registerCommand(new CmdAdminSetBlockAmount());
-        registerCommand(new CmdAdminSetBlockLimit());
         registerCommand(new CmdAdminSetBonus());
         registerCommand(new CmdAdminSetChestRow());
         if (plugin.getSettings().isCoopMembers())
             registerCommand(new CmdAdminSetCoopLimit());
         registerCommand(new CmdAdminSetDisbands());
-        registerCommand(new CmdAdminSetEntityLimit());
         registerCommand(new CmdAdminSetIslandPreview());
         registerCommand(new CmdAdminSetLeader());
         registerCommand(new CmdAdminSetPermission());

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminAddBlockLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminAddBlockLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.upgrades.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminAddEntityLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminAddEntityLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.upgrades.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
@@ -7,50 +7,54 @@ import com.bgsoftware.superiorskyblock.api.key.Key;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
+import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
+import com.bgsoftware.superiorskyblock.commands.arguments.NumberArgument;
+import com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs;
+import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEvent;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.key.Keys;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class CmdAdminRemoveBlockLimit implements IAdminIslandCommand {
+public class CmdAdminAddEntityLimit implements IAdminIslandCommand {
 
     @Override
     public List<String> getAliases() {
-        return Arrays.asList("removeblocklimit", "remblocklimit");
+        return Collections.singletonList("addentitylimit");
     }
 
     @Override
     public String getPermission() {
-        return "superior.admin.removeblocklimit";
+        return "superior.admin.addentitylimit";
     }
 
     @Override
     public String getUsage(java.util.Locale locale) {
-        return "admin removeblocklimit <" +
+        return "admin addentitylimit <" +
                 Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ALL_ISLANDS.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_MATERIAL.getMessage(locale) + ">";
+                Message.COMMAND_ARGUMENT_ENTITY.getMessage(locale) + "> <" +
+                Message.COMMAND_ARGUMENT_LIMIT.getMessage(locale) + ">";
     }
 
     @Override
     public String getDescription(java.util.Locale locale) {
-        return Message.COMMAND_DESCRIPTION_ADMIN_REMOVE_BLOCK_LIMIT.getMessage(locale);
+        return Message.COMMAND_DESCRIPTION_ADMIN_ADD_ENTITY_LIMIT.getMessage(locale);
     }
 
     @Override
     public int getMinArgs() {
-        return 4;
+        return 5;
     }
 
     @Override
     public int getMaxArgs() {
-        return 4;
+        return 5;
     }
 
     @Override
@@ -65,14 +69,23 @@ public class CmdAdminRemoveBlockLimit implements IAdminIslandCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, @Nullable SuperiorPlayer targetPlayer, List<Island> islands, String[] args) {
-        Key key = Keys.ofMaterialAndData(args[3]);
+        Key entityKey = Keys.ofEntityType(args[3]);
+
+        NumberArgument<Integer> arguments = CommandArguments.getLimit(sender, args[4]);
+
+        if (!arguments.isSucceed())
+            return;
+
+        int limit = arguments.getNumber();
 
         int islandsChangedCount = 0;
 
         for (Island island : islands) {
-            if (PluginEventsFactory.callIslandRemoveBlockLimitEvent(island, sender, key)) {
+            PluginEvent<PluginEventArgs.IslandChangeEntityLimit> event = PluginEventsFactory.callIslandChangeEntityLimitEvent(
+                    island, sender, entityKey, island.getEntityLimit(entityKey) + limit);
+            if (!event.isCancelled()) {
+                island.setEntityLimit(entityKey, event.getArgs().entityLimit);
                 ++islandsChangedCount;
-                island.removeBlockLimit(key);
             }
         }
 
@@ -80,16 +93,16 @@ public class CmdAdminRemoveBlockLimit implements IAdminIslandCommand {
             return;
 
         if (islandsChangedCount > 1)
-            Message.CHANGED_BLOCK_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()));
+            Message.CHANGED_ENTITY_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()));
         else if (targetPlayer == null)
-            Message.CHANGED_BLOCK_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), islands.get(0).getName());
+            Message.CHANGED_ENTITY_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), islands.get(0).getName());
         else
-            Message.CHANGED_BLOCK_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), targetPlayer.getName());
+            Message.CHANGED_ENTITY_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), targetPlayer.getName());
     }
 
     @Override
     public List<String> adminTabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, Island island, String[] args) {
-        return args.length == 4 ? CommandTabCompletes.getMaterials(args[3]) : Collections.emptyList();
+        return args.length == 4 ? CommandTabCompletes.getEntitiesForLimit(args[3]) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminRemoveBlockLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminRemoveBlockLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.upgrades.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
@@ -7,54 +7,50 @@ import com.bgsoftware.superiorskyblock.api.key.Key;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
-import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
-import com.bgsoftware.superiorskyblock.commands.arguments.NumberArgument;
-import com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs;
-import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEvent;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.key.Keys;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class CmdAdminSetBlockLimit implements IAdminIslandCommand {
+public class CmdAdminRemoveBlockLimit implements IAdminIslandCommand {
 
     @Override
     public List<String> getAliases() {
-        return Collections.singletonList("setblocklimit");
+        return Arrays.asList("removeblocklimit", "remblocklimit");
     }
 
     @Override
     public String getPermission() {
-        return "superior.admin.setblocklimit";
+        return "superior.admin.removeblocklimit";
     }
 
     @Override
     public String getUsage(java.util.Locale locale) {
-        return "admin setblocklimit <" +
+        return "admin removeblocklimit <" +
                 Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ALL_ISLANDS.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_MATERIAL.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_LIMIT.getMessage(locale) + ">";
+                Message.COMMAND_ARGUMENT_MATERIAL.getMessage(locale) + ">";
     }
 
     @Override
     public String getDescription(java.util.Locale locale) {
-        return Message.COMMAND_DESCRIPTION_ADMIN_SET_BLOCK_LIMIT.getMessage(locale);
+        return Message.COMMAND_DESCRIPTION_ADMIN_REMOVE_BLOCK_LIMIT.getMessage(locale);
     }
 
     @Override
     public int getMinArgs() {
-        return 5;
+        return 4;
     }
 
     @Override
     public int getMaxArgs() {
-        return 5;
+        return 4;
     }
 
     @Override
@@ -71,20 +67,12 @@ public class CmdAdminSetBlockLimit implements IAdminIslandCommand {
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, @Nullable SuperiorPlayer targetPlayer, List<Island> islands, String[] args) {
         Key key = Keys.ofMaterialAndData(args[3]);
 
-        NumberArgument<Integer> arguments = CommandArguments.getLimit(sender, args[4]);
-
-        if (!arguments.isSucceed())
-            return;
-
-        int limit = arguments.getNumber();
-
         int islandsChangedCount = 0;
 
         for (Island island : islands) {
-            PluginEvent<PluginEventArgs.IslandChangeBlockLimit> event = PluginEventsFactory.callIslandChangeBlockLimitEvent(island, sender, key, limit);
-            if (!event.isCancelled()) {
-                island.setBlockLimit(key, event.getArgs().blockLimit);
+            if (PluginEventsFactory.callIslandRemoveBlockLimitEvent(island, sender, key)) {
                 ++islandsChangedCount;
+                island.removeBlockLimit(key);
             }
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminRemoveEntityLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminRemoveEntityLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.upgrades.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
@@ -7,54 +7,50 @@ import com.bgsoftware.superiorskyblock.api.key.Key;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
-import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
-import com.bgsoftware.superiorskyblock.commands.arguments.NumberArgument;
-import com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs;
-import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEvent;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.key.Keys;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class CmdAdminAddEntityLimit implements IAdminIslandCommand {
+public class CmdAdminRemoveEntityLimit implements IAdminIslandCommand {
 
     @Override
     public List<String> getAliases() {
-        return Collections.singletonList("addentitylimit");
+        return Arrays.asList("removeentitylimit", "rementitylimit");
     }
 
     @Override
     public String getPermission() {
-        return "superior.admin.addentitylimit";
+        return "superior.admin.removeentitylimit";
     }
 
     @Override
     public String getUsage(java.util.Locale locale) {
-        return "admin addentitylimit <" +
+        return "admin removeentitylimit <" +
                 Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ALL_ISLANDS.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_ENTITY.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_LIMIT.getMessage(locale) + ">";
+                Message.COMMAND_ARGUMENT_ENTITY.getMessage(locale) + ">";
     }
 
     @Override
     public String getDescription(java.util.Locale locale) {
-        return Message.COMMAND_DESCRIPTION_ADMIN_ADD_ENTITY_LIMIT.getMessage(locale);
+        return Message.COMMAND_DESCRIPTION_ADMIN_REMOVE_ENTITY_LIMIT.getMessage(locale);
     }
 
     @Override
     public int getMinArgs() {
-        return 5;
+        return 4;
     }
 
     @Override
     public int getMaxArgs() {
-        return 5;
+        return 4;
     }
 
     @Override
@@ -69,23 +65,14 @@ public class CmdAdminAddEntityLimit implements IAdminIslandCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, @Nullable SuperiorPlayer targetPlayer, List<Island> islands, String[] args) {
-        Key entityKey = Keys.ofEntityType(args[3]);
-
-        NumberArgument<Integer> arguments = CommandArguments.getLimit(sender, args[4]);
-
-        if (!arguments.isSucceed())
-            return;
-
-        int limit = arguments.getNumber();
+        Key key = Keys.ofEntityType(args[3]);
 
         int islandsChangedCount = 0;
 
         for (Island island : islands) {
-            PluginEvent<PluginEventArgs.IslandChangeEntityLimit> event = PluginEventsFactory.callIslandChangeEntityLimitEvent(
-                    island, sender, entityKey, island.getEntityLimit(entityKey) + limit);
-            if (!event.isCancelled()) {
-                island.setEntityLimit(entityKey, event.getArgs().entityLimit);
+            if (PluginEventsFactory.callIslandRemoveEntityLimitEvent(island, sender, key)) {
                 ++islandsChangedCount;
+                island.removeEntityLimit(key);
             }
         }
 
@@ -93,11 +80,11 @@ public class CmdAdminAddEntityLimit implements IAdminIslandCommand {
             return;
 
         if (islandsChangedCount > 1)
-            Message.CHANGED_ENTITY_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()));
+            Message.CHANGED_ENTITY_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()));
         else if (targetPlayer == null)
-            Message.CHANGED_ENTITY_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), islands.get(0).getName());
+            Message.CHANGED_ENTITY_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), islands.get(0).getName());
         else
-            Message.CHANGED_ENTITY_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), targetPlayer.getName());
+            Message.CHANGED_ENTITY_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), targetPlayer.getName());
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminSetBlockLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminSetBlockLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.upgrades.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
@@ -20,31 +20,31 @@ import org.bukkit.command.CommandSender;
 import java.util.Collections;
 import java.util.List;
 
-public class CmdAdminSetEntityLimit implements IAdminIslandCommand {
+public class CmdAdminSetBlockLimit implements IAdminIslandCommand {
 
     @Override
     public List<String> getAliases() {
-        return Collections.singletonList("setentitylimit");
+        return Collections.singletonList("setblocklimit");
     }
 
     @Override
     public String getPermission() {
-        return "superior.admin.setentitylimit";
+        return "superior.admin.setblocklimit";
     }
 
     @Override
     public String getUsage(java.util.Locale locale) {
-        return "admin setentitylimit <" +
+        return "admin setblocklimit <" +
                 Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ALL_ISLANDS.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_ENTITY.getMessage(locale) + "> <" +
+                Message.COMMAND_ARGUMENT_MATERIAL.getMessage(locale) + "> <" +
                 Message.COMMAND_ARGUMENT_LIMIT.getMessage(locale) + ">";
     }
 
     @Override
     public String getDescription(java.util.Locale locale) {
-        return Message.COMMAND_DESCRIPTION_ADMIN_SET_ENTITY_LIMIT.getMessage(locale);
+        return Message.COMMAND_DESCRIPTION_ADMIN_SET_BLOCK_LIMIT.getMessage(locale);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class CmdAdminSetEntityLimit implements IAdminIslandCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, @Nullable SuperiorPlayer targetPlayer, List<Island> islands, String[] args) {
-        Key entityKey = Keys.ofEntityType(args[3]);
+        Key key = Keys.ofMaterialAndData(args[3]);
 
         NumberArgument<Integer> arguments = CommandArguments.getLimit(sender, args[4]);
 
@@ -81,10 +81,9 @@ public class CmdAdminSetEntityLimit implements IAdminIslandCommand {
         int islandsChangedCount = 0;
 
         for (Island island : islands) {
-            PluginEvent<PluginEventArgs.IslandChangeEntityLimit> event = PluginEventsFactory.callIslandChangeEntityLimitEvent(
-                    island, sender, entityKey, limit);
+            PluginEvent<PluginEventArgs.IslandChangeBlockLimit> event = PluginEventsFactory.callIslandChangeBlockLimitEvent(island, sender, key, limit);
             if (!event.isCancelled()) {
-                island.setEntityLimit(entityKey, event.getArgs().entityLimit);
+                island.setBlockLimit(key, event.getArgs().blockLimit);
                 ++islandsChangedCount;
             }
         }
@@ -93,16 +92,16 @@ public class CmdAdminSetEntityLimit implements IAdminIslandCommand {
             return;
 
         if (islandsChangedCount > 1)
-            Message.CHANGED_ENTITY_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()));
+            Message.CHANGED_BLOCK_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()));
         else if (targetPlayer == null)
-            Message.CHANGED_ENTITY_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), islands.get(0).getName());
+            Message.CHANGED_BLOCK_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), islands.get(0).getName());
         else
-            Message.CHANGED_ENTITY_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), targetPlayer.getName());
+            Message.CHANGED_BLOCK_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), targetPlayer.getName());
     }
 
     @Override
     public List<String> adminTabComplete(SuperiorSkyblockPlugin plugin, CommandSender sender, Island island, String[] args) {
-        return args.length == 4 ? CommandTabCompletes.getEntitiesForLimit(args[3]) : Collections.emptyList();
+        return args.length == 4 ? CommandTabCompletes.getMaterials(args[3]) : Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminSetEntityLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/commands/CmdAdminSetEntityLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.upgrades.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
@@ -7,50 +7,54 @@ import com.bgsoftware.superiorskyblock.api.key.Key;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IAdminIslandCommand;
+import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
+import com.bgsoftware.superiorskyblock.commands.arguments.NumberArgument;
+import com.bgsoftware.superiorskyblock.core.events.args.PluginEventArgs;
+import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEvent;
 import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.key.Keys;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class CmdAdminRemoveEntityLimit implements IAdminIslandCommand {
+public class CmdAdminSetEntityLimit implements IAdminIslandCommand {
 
     @Override
     public List<String> getAliases() {
-        return Arrays.asList("removeentitylimit", "rementitylimit");
+        return Collections.singletonList("setentitylimit");
     }
 
     @Override
     public String getPermission() {
-        return "superior.admin.removeentitylimit";
+        return "superior.admin.setentitylimit";
     }
 
     @Override
     public String getUsage(java.util.Locale locale) {
-        return "admin removeentitylimit <" +
+        return "admin setentitylimit <" +
                 Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "/" +
                 Message.COMMAND_ARGUMENT_ALL_ISLANDS.getMessage(locale) + "> <" +
-                Message.COMMAND_ARGUMENT_ENTITY.getMessage(locale) + ">";
+                Message.COMMAND_ARGUMENT_ENTITY.getMessage(locale) + "> <" +
+                Message.COMMAND_ARGUMENT_LIMIT.getMessage(locale) + ">";
     }
 
     @Override
     public String getDescription(java.util.Locale locale) {
-        return Message.COMMAND_DESCRIPTION_ADMIN_REMOVE_ENTITY_LIMIT.getMessage(locale);
+        return Message.COMMAND_DESCRIPTION_ADMIN_SET_ENTITY_LIMIT.getMessage(locale);
     }
 
     @Override
     public int getMinArgs() {
-        return 4;
+        return 5;
     }
 
     @Override
     public int getMaxArgs() {
-        return 4;
+        return 5;
     }
 
     @Override
@@ -65,14 +69,23 @@ public class CmdAdminRemoveEntityLimit implements IAdminIslandCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, @Nullable SuperiorPlayer targetPlayer, List<Island> islands, String[] args) {
-        Key key = Keys.ofEntityType(args[3]);
+        Key entityKey = Keys.ofEntityType(args[3]);
+
+        NumberArgument<Integer> arguments = CommandArguments.getLimit(sender, args[4]);
+
+        if (!arguments.isSucceed())
+            return;
+
+        int limit = arguments.getNumber();
 
         int islandsChangedCount = 0;
 
         for (Island island : islands) {
-            if (PluginEventsFactory.callIslandRemoveEntityLimitEvent(island, sender, key)) {
+            PluginEvent<PluginEventArgs.IslandChangeEntityLimit> event = PluginEventsFactory.callIslandChangeEntityLimitEvent(
+                    island, sender, entityKey, limit);
+            if (!event.isCancelled()) {
+                island.setEntityLimit(entityKey, event.getArgs().entityLimit);
                 ++islandsChangedCount;
-                island.removeEntityLimit(key);
             }
         }
 
@@ -80,11 +93,11 @@ public class CmdAdminRemoveEntityLimit implements IAdminIslandCommand {
             return;
 
         if (islandsChangedCount > 1)
-            Message.CHANGED_ENTITY_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()));
+            Message.CHANGED_ENTITY_LIMIT_ALL.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()));
         else if (targetPlayer == null)
-            Message.CHANGED_ENTITY_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), islands.get(0).getName());
+            Message.CHANGED_ENTITY_LIMIT_NAME.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), islands.get(0).getName());
         else
-            Message.CHANGED_ENTITY_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(key.getGlobalKey()), targetPlayer.getName());
+            Message.CHANGED_ENTITY_LIMIT.send(sender, Formatters.CAPITALIZED_FORMATTER.format(entityKey.getGlobalKey()), targetPlayer.getName());
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeBlockLimits.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeBlockLimits.java
@@ -14,6 +14,9 @@ import com.bgsoftware.superiorskyblock.core.key.ConstantKeys;
 import com.bgsoftware.superiorskyblock.core.key.Keys;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.core.mutable.MutableObject;
+import com.bgsoftware.superiorskyblock.module.upgrades.commands.CmdAdminAddBlockLimit;
+import com.bgsoftware.superiorskyblock.module.upgrades.commands.CmdAdminRemoveBlockLimit;
+import com.bgsoftware.superiorskyblock.module.upgrades.commands.CmdAdminSetBlockLimit;
 import com.bgsoftware.superiorskyblock.world.BukkitItems;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -33,10 +36,14 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Directional;
 import org.bukkit.material.MaterialData;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class UpgradeTypeBlockLimits implements IUpgradeType {
+
+    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddBlockLimit(),
+            new CmdAdminRemoveBlockLimit(), new CmdAdminSetBlockLimit());
 
     private final SuperiorSkyblockPlugin plugin;
 
@@ -51,7 +58,7 @@ public class UpgradeTypeBlockLimits implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return Collections.emptyList();
+        return commands;
     }
 
     private class BlockLimitsListener implements Listener {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeBlockLimits.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeBlockLimits.java
@@ -42,9 +42,6 @@ import java.util.List;
 
 public class UpgradeTypeBlockLimits implements IUpgradeType {
 
-    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddBlockLimit(),
-            new CmdAdminRemoveBlockLimit(), new CmdAdminSetBlockLimit());
-
     private final SuperiorSkyblockPlugin plugin;
 
     public UpgradeTypeBlockLimits(SuperiorSkyblockPlugin plugin) {
@@ -58,7 +55,7 @@ public class UpgradeTypeBlockLimits implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return commands;
+        return Arrays.asList(new CmdAdminAddBlockLimit(), new CmdAdminRemoveBlockLimit(), new CmdAdminSetBlockLimit());
     }
 
     private class BlockLimitsListener implements Listener {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeCropGrowth.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeCropGrowth.java
@@ -18,9 +18,6 @@ import java.util.List;
 
 public class UpgradeTypeCropGrowth implements IUpgradeType {
 
-    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddCropGrowth(),
-            new CmdAdminSetCropGrowth());
-
     private final SuperiorSkyblockPlugin plugin;
 
     public UpgradeTypeCropGrowth(SuperiorSkyblockPlugin plugin) {
@@ -34,7 +31,7 @@ public class UpgradeTypeCropGrowth implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return commands;
+        return Arrays.asList(new CmdAdminAddCropGrowth(), new CmdAdminSetCropGrowth());
     }
 
     private class CropGrowthListener implements Listener {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeEntityLimits.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeEntityLimits.java
@@ -15,6 +15,9 @@ import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.key.Keys;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.core.threads.BukkitExecutor;
+import com.bgsoftware.superiorskyblock.module.upgrades.commands.CmdAdminAddEntityLimit;
+import com.bgsoftware.superiorskyblock.module.upgrades.commands.CmdAdminRemoveEntityLimit;
+import com.bgsoftware.superiorskyblock.module.upgrades.commands.CmdAdminSetEntityLimit;
 import com.bgsoftware.superiorskyblock.world.BukkitEntities;
 import com.bgsoftware.superiorskyblock.world.BukkitItems;
 import org.bukkit.Location;
@@ -37,14 +40,13 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
 import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class UpgradeTypeEntityLimits implements IUpgradeType {
+
+    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddEntityLimit(),
+            new CmdAdminRemoveEntityLimit(), new CmdAdminSetEntityLimit());
 
     private final Map<EntityType, SpawningPlayerData> entityBreederPlayers = AutoRemovalMap.newHashMap(2, TimeUnit.SECONDS);
     private final Map<Location, SpawningPlayerData> vehiclesOwners = AutoRemovalMap.newMap(2, TimeUnit.SECONDS, Location2ObjectMap::new);
@@ -69,7 +71,7 @@ public class UpgradeTypeEntityLimits implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return Collections.emptyList();
+        return commands;
     }
 
     private Optional<Listener> checkEntityBreedListener() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeEntityLimits.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeEntityLimits.java
@@ -40,7 +40,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
 import java.lang.ref.WeakReference;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class UpgradeTypeEntityLimits implements IUpgradeType {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeEntityLimits.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeEntityLimits.java
@@ -49,9 +49,6 @@ import java.util.concurrent.TimeUnit;
 
 public class UpgradeTypeEntityLimits implements IUpgradeType {
 
-    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddEntityLimit(),
-            new CmdAdminRemoveEntityLimit(), new CmdAdminSetEntityLimit());
-
     private final Map<EntityType, SpawningPlayerData> entityBreederPlayers = AutoRemovalMap.newHashMap(2, TimeUnit.SECONDS);
     private final Map<Location, SpawningPlayerData> vehiclesOwners = AutoRemovalMap.newMap(2, TimeUnit.SECONDS, Location2ObjectMap::new);
     private final Map<EntityType, SpawningPlayerData> spawnEggPlayers = AutoRemovalMap.newHashMap(2, TimeUnit.SECONDS);
@@ -75,7 +72,7 @@ public class UpgradeTypeEntityLimits implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return commands;
+        return Arrays.asList(new CmdAdminAddEntityLimit(), new CmdAdminRemoveEntityLimit(), new CmdAdminSetEntityLimit());
     }
 
     private Optional<Listener> checkEntityBreedListener() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeIslandEffects.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeIslandEffects.java
@@ -19,9 +19,6 @@ import java.util.List;
 
 public class UpgradeTypeIslandEffects implements IUpgradeType {
 
-    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddEffect(),
-            new CmdAdminSetEffect());
-
     private final SuperiorSkyblockPlugin plugin;
 
     public UpgradeTypeIslandEffects(SuperiorSkyblockPlugin plugin) {
@@ -37,7 +34,7 @@ public class UpgradeTypeIslandEffects implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return commands;
+        return Arrays.asList(new CmdAdminAddEffect(), new CmdAdminSetEffect());
     }
 
     private class IslandEffectsListener implements Listener {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeMobDrops.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeMobDrops.java
@@ -28,9 +28,6 @@ import java.util.List;
 
 public class UpgradeTypeMobDrops implements IUpgradeType {
 
-    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddMobDrops(),
-            new CmdAdminSetMobDrops());
-
     private final SuperiorSkyblockPlugin plugin;
     private final boolean isWildStackerInstalled;
 
@@ -46,7 +43,7 @@ public class UpgradeTypeMobDrops implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return commands;
+        return Arrays.asList(new CmdAdminAddMobDrops(), new CmdAdminSetMobDrops());
     }
 
     private static boolean canDupeDropsForEntity(Entity entity) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeSpawnerRates.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/type/UpgradeTypeSpawnerRates.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 public class UpgradeTypeSpawnerRates implements IUpgradeType {
 
-    private static final List<ISuperiorCommand> commands = Arrays.asList(new CmdAdminAddSpawnerRates(),
-            new CmdAdminSetSpawnerRates());
-
     private final SuperiorSkyblockPlugin plugin;
 
     public UpgradeTypeSpawnerRates(SuperiorSkyblockPlugin plugin) {
@@ -38,7 +35,7 @@ public class UpgradeTypeSpawnerRates implements IUpgradeType {
 
     @Override
     public List<ISuperiorCommand> getCommands() {
-        return commands;
+        return Arrays.asList(new CmdAdminAddSpawnerRates(), new CmdAdminSetSpawnerRates());
     }
 
     public void handleSpawnerPlace(Block block) {

--- a/src/main/resources/modules/bank/config.yml
+++ b/src/main/resources/modules/bank/config.yml
@@ -5,6 +5,8 @@
 ##                                                  ##
 ######################################################
 
+# Whether the module should be enabled.
+# When disabled, all module commands and features will also be disabled.
 enabled: true
 
 # Set the divider for the island bank money in the total island worth.

--- a/src/main/resources/modules/generators/config.yml
+++ b/src/main/resources/modules/generators/config.yml
@@ -5,6 +5,8 @@
 ##                                                  ##
 ######################################################
 
+# Whether the module should be enabled.
+# When disabled, all module commands and features will also be disabled.
 enabled: true
 
 # Whether generators should match their intended world instead of the world they actually generate in.

--- a/src/main/resources/modules/missions/config.yml
+++ b/src/main/resources/modules/missions/config.yml
@@ -5,7 +5,8 @@
 ##                                                  ##
 ######################################################
 
-# Should missions be enabled on your server?
+# Whether the module should be enabled.
+# When disabled, all module commands and features will also be disabled.
 enabled: true
 
 # Should mission rewards be automatically claimed outside island worlds?

--- a/src/main/resources/modules/upgrades/config.yml
+++ b/src/main/resources/modules/upgrades/config.yml
@@ -5,6 +5,8 @@
 ##                                                  ##
 ######################################################
 
+# Whether the module should be enabled.
+# When disabled, all module commands and features will also be disabled.
 enabled: true
 
 # Whether crop-growth should be enabled.

--- a/src/main/resources/modules/upgrades/config.yml
+++ b/src/main/resources/modules/upgrades/config.yml
@@ -5,6 +5,8 @@
 ##                                                  ##
 ######################################################
 
+enabled: true
+
 # Whether crop-growth should be enabled.
 # When disabled, the plugin will not alter crop growth.
 crop-growth: true


### PR DESCRIPTION
# Changelog # 
- I added an "enabled" option to the upgrades module config because if we disabled all options from this config, the module was disabled, which shouldn't be the case, as we might still want to use the upgrades menu to upgrade the team limit or island size, which are part of the main plugin, so still work despite these options being disabled. 
- I moved the block and entity limit modification commands to the upgrades module because you can specify whether these features are enabled in the module, but these commands didn't belong to the module, but to the main plugin, and they were always enabled.