### PR TITLE
Moved /is admin setbanklimit command to the bank module

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/AdminCommandsMap.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/AdminCommandsMap.java
@@ -54,7 +54,6 @@ public class AdminCommandsMap extends CommandsMap {
         registerCommand(new CmdAdminResetSettings());
         registerCommand(new CmdAdminResetWorld());
         registerCommand(new CmdAdminSchematic());
-        registerCommand(new CmdAdminSetBankLimit());
         registerCommand(new CmdAdminSetBiome());
         registerCommand(new CmdAdminSetBlockAmount());
         registerCommand(new CmdAdminSetBlockLimit());

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminShow.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminShow.java
@@ -193,7 +193,8 @@ public class CmdAdminShow implements IAdminIslandCommand {
             collectIslandData(locale, infoMessage, island::getCoopLimit, island::getCoopLimitRaw, Message.ISLAND_INFO_ADMIN_COOP_LIMIT);
 
         // Island bank limit
-        collectIslandData(locale, infoMessage, island::getBankLimit, island::getBankLimitRaw, Message.ISLAND_INFO_ADMIN_BANK_LIMIT,
+        if (BuiltinModules.BANK.isEnabled())
+            collectIslandData(locale, infoMessage, island::getBankLimit, island::getBankLimitRaw, Message.ISLAND_INFO_ADMIN_BANK_LIMIT,
                 Formatters.NUMBER_FORMATTER::format);
 
         if (upgradesModule) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/bank/BankModule.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/bank/BankModule.java
@@ -5,7 +5,13 @@ import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.commands.SuperiorCommand;
 import com.bgsoftware.superiorskyblock.module.BuiltinModule;
 import com.bgsoftware.superiorskyblock.module.IModuleConfiguration;
-import com.bgsoftware.superiorskyblock.module.bank.commands.*;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdAdminDeposit;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdAdminSetBankLimit;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdAdminWithdraw;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdBalance;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdBank;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdDeposit;
+import com.bgsoftware.superiorskyblock.module.bank.commands.CmdWithdraw;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/bank/BankModule.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/bank/BankModule.java
@@ -5,12 +5,7 @@ import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.commands.SuperiorCommand;
 import com.bgsoftware.superiorskyblock.module.BuiltinModule;
 import com.bgsoftware.superiorskyblock.module.IModuleConfiguration;
-import com.bgsoftware.superiorskyblock.module.bank.commands.CmdAdminDeposit;
-import com.bgsoftware.superiorskyblock.module.bank.commands.CmdAdminWithdraw;
-import com.bgsoftware.superiorskyblock.module.bank.commands.CmdBalance;
-import com.bgsoftware.superiorskyblock.module.bank.commands.CmdBank;
-import com.bgsoftware.superiorskyblock.module.bank.commands.CmdDeposit;
-import com.bgsoftware.superiorskyblock.module.bank.commands.CmdWithdraw;
+import com.bgsoftware.superiorskyblock.module.bank.commands.*;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 
@@ -77,7 +72,7 @@ public class BankModule extends BuiltinModule<BankModule.Configuration> {
 
     @Override
     public SuperiorCommand[] getSuperiorAdminCommands(SuperiorSkyblockPlugin plugin) {
-        return new SuperiorCommand[]{new CmdAdminDeposit(), new CmdAdminWithdraw()};
+        return new SuperiorCommand[]{new CmdAdminDeposit(), new CmdAdminSetBankLimit(), new CmdAdminWithdraw()};
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdAdminSetBankLimit.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdAdminSetBankLimit.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.commands.admin;
+package com.bgsoftware.superiorskyblock.module.bank.commands;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;


### PR DESCRIPTION
I've moved the /is admin setbanklimit command to the bank module because why set the bank limit if the bank is disabled? For the same reason, I've also disabled the bank limit display in /is admin show when the bank module is disabled.