### PR TITLE
Fixed loading upgrades when all upgrade types are disabled

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/UpgradesModule.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/UpgradesModule.java
@@ -191,22 +191,24 @@ public class UpgradesModule extends BuiltinModule<UpgradesModule.Configuration> 
         }
 
         private void loadUpgrades(CommentedConfiguration config) {
-            if (config.getBoolean("crop-growth", true))
-                enabledUpgrades.add(new UpgradeTypeCropGrowth(plugin));
-            if (config.getBoolean("mob-drops", true))
-                enabledUpgrades.add(new UpgradeTypeMobDrops(plugin));
-            if (config.getBoolean("island-effects", true))
-                enabledUpgrades.add(new UpgradeTypeIslandEffects(plugin));
-            if (config.getBoolean("spawner-rates", true))
-                enabledUpgrades.add(new UpgradeTypeSpawnerRates(plugin));
-            if (config.getBoolean("block-limits", true))
-                enabledUpgrades.add(new UpgradeTypeBlockLimits(plugin));
-            if (config.getBoolean("entity-limits", true))
-                enabledUpgrades.add(new UpgradeTypeEntityLimits(plugin));
+            if (enabled) {
+                if (config.getBoolean("crop-growth", true))
+                    enabledUpgrades.add(new UpgradeTypeCropGrowth(plugin));
+                if (config.getBoolean("mob-drops", true))
+                    enabledUpgrades.add(new UpgradeTypeMobDrops(plugin));
+                if (config.getBoolean("island-effects", true))
+                    enabledUpgrades.add(new UpgradeTypeIslandEffects(plugin));
+                if (config.getBoolean("spawner-rates", true))
+                    enabledUpgrades.add(new UpgradeTypeSpawnerRates(plugin));
+                if (config.getBoolean("block-limits", true))
+                    enabledUpgrades.add(new UpgradeTypeBlockLimits(plugin));
+                if (config.getBoolean("entity-limits", true))
+                    enabledUpgrades.add(new UpgradeTypeEntityLimits(plugin));
+            }
 
             plugin.getUpgrades().clearUpgrades();
 
-            if (!enabledUpgrades.isEmpty()) {
+            if (enabled) {
                 ConfigurationSection upgrades = config.getConfigurationSection("upgrades");
                 if (upgrades != null) {
                     for (String upgradeName : upgrades.getKeys(false)) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/UpgradesModule.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/upgrades/UpgradesModule.java
@@ -191,37 +191,35 @@ public class UpgradesModule extends BuiltinModule<UpgradesModule.Configuration> 
         }
 
         private void loadUpgrades(CommentedConfiguration config) {
-            if (enabled) {
-                if (config.getBoolean("crop-growth", true))
-                    enabledUpgrades.add(new UpgradeTypeCropGrowth(plugin));
-                if (config.getBoolean("mob-drops", true))
-                    enabledUpgrades.add(new UpgradeTypeMobDrops(plugin));
-                if (config.getBoolean("island-effects", true))
-                    enabledUpgrades.add(new UpgradeTypeIslandEffects(plugin));
-                if (config.getBoolean("spawner-rates", true))
-                    enabledUpgrades.add(new UpgradeTypeSpawnerRates(plugin));
-                if (config.getBoolean("block-limits", true))
-                    enabledUpgrades.add(new UpgradeTypeBlockLimits(plugin));
-                if (config.getBoolean("entity-limits", true))
-                    enabledUpgrades.add(new UpgradeTypeEntityLimits(plugin));
-            }
-
             plugin.getUpgrades().clearUpgrades();
 
-            if (enabled) {
-                ConfigurationSection upgrades = config.getConfigurationSection("upgrades");
-                if (upgrades != null) {
-                    for (String upgradeName : upgrades.getKeys(false)) {
-                        if (upgradeName.length() > MAX_UPGRADES_NAME_LENGTH)
-                            upgradeName = upgradeName.substring(0, MAX_UPGRADES_NAME_LENGTH);
+            if (!enabled) return;
 
-                        SUpgrade upgrade = new SUpgrade(upgradeName);
-                        for (String _level : upgrades.getConfigurationSection(upgradeName).getKeys(false)) {
-                            loadUpgradeLevelFromSection(plugin, upgrade, _level, upgrades.getConfigurationSection(upgradeName + "." + _level));
-                        }
+            if (config.getBoolean("crop-growth", true))
+                enabledUpgrades.add(new UpgradeTypeCropGrowth(plugin));
+            if (config.getBoolean("mob-drops", true))
+                enabledUpgrades.add(new UpgradeTypeMobDrops(plugin));
+            if (config.getBoolean("island-effects", true))
+                enabledUpgrades.add(new UpgradeTypeIslandEffects(plugin));
+            if (config.getBoolean("spawner-rates", true))
+                enabledUpgrades.add(new UpgradeTypeSpawnerRates(plugin));
+            if (config.getBoolean("block-limits", true))
+                enabledUpgrades.add(new UpgradeTypeBlockLimits(plugin));
+            if (config.getBoolean("entity-limits", true))
+                enabledUpgrades.add(new UpgradeTypeEntityLimits(plugin));
 
-                        plugin.getUpgrades().addUpgrade(upgrade);
+            ConfigurationSection upgrades = config.getConfigurationSection("upgrades");
+            if (upgrades != null) {
+                for (String upgradeName : upgrades.getKeys(false)) {
+                    if (upgradeName.length() > MAX_UPGRADES_NAME_LENGTH)
+                        upgradeName = upgradeName.substring(0, MAX_UPGRADES_NAME_LENGTH);
+
+                    SUpgrade upgrade = new SUpgrade(upgradeName);
+                    for (String _level : upgrades.getConfigurationSection(upgradeName).getKeys(false)) {
+                        loadUpgradeLevelFromSection(plugin, upgrade, _level, upgrades.getConfigurationSection(upgradeName + "." + _level));
                     }
+
+                    plugin.getUpgrades().addUpgrade(upgrade);
                 }
             }
 


### PR DESCRIPTION
loadUpgrades() still checked whether to load upgrades based on enabled upgrade types, instead of whether the module was enabled 😓