### PR TITLE
Fixed placing Bamboo Rafts without permissions

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/Materials.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/Materials.java
@@ -162,7 +162,7 @@ public enum Materials {
                     material == Material.TRAPPED_CHEST || materialName.contains("SHULKER_BOX") ||
                     materialName.equals("BARREL"))
                 materialTags.add(Tag.CHEST);
-            if (materialName.contains("BOAT"))
+            if (materialName.contains("BOAT") || materialName.contains("_RAFT"))
                 materialTags.add(Tag.BOAT);
             if (materialName.contains("LAVA"))
                 materialTags.add(Tag.LAVA);


### PR DESCRIPTION
Bamboo Rafts do not have the word "Boat" in them, so they were not considered boats and could be placed without permission