### PR TITLE
Fix loading locations from config

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminSetIslandPreview.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminSetIslandPreview.java
@@ -66,6 +66,11 @@ public class CmdAdminSetIslandPreview implements ISuperiorCommand {
         String schematicPreviewLocation;
         try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
             Location location = player.getLocation(wrapper.getHandle());
+            location.setX(location.getBlockX());
+            location.setY(location.getBlockY());
+            location.setZ(location.getBlockZ());
+            // Fix to corner of a block
+            location.add(0.5, 0, 0.5);
             schematicPreviewLocation = Serializers.LOCATION_SPACED_SERIALIZER.serialize(location);
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -573,7 +573,7 @@ public class SettingsContainer {
         if (config.isConfigurationSection("island-previews.locations")) {
             for (String schematic : config.getConfigurationSection("island-previews.locations").getKeys(false)) {
                 try {
-                    islandPreviewsLocations.put(schematic.toLowerCase(Locale.ENGLISH), Serializers.LOCATION_SERIALIZER
+                    islandPreviewsLocations.put(schematic.toLowerCase(Locale.ENGLISH), Serializers.LOCATION_SPACED_CENTERED_SERIALIZER
                             .deserialize(config.getString("island-previews.locations." + schematic)));
                 } catch (Exception error) {
                     Log.warnFromFile("config.yml", "Cannot deserialize island preview for ", schematic, ", skipping...");

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/serialization/Serializers.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/serialization/Serializers.java
@@ -19,6 +19,7 @@ public class Serializers {
     public static final ISerializer<ItemStack[], byte[]> INVENTORY_SERIALIZER = InventorySerializer.getInstance();
     public static final ISerializer<ItemStack, String> ITEM_STACK_SERIALIZER = ItemStackSerializer.getInstance();
     public static final ISerializer<ItemStack, CompoundTag> ITEM_STACK_TO_TAG_SERIALIZER = ItemStack2TagSerializer.getInstance();
+    public static final ISerializer<Location, String> LOCATION_SPACED_CENTERED_SERIALIZER = new LocationSerializer(", ", true);
     public static final ISerializer<Location, String> LOCATION_SPACED_SERIALIZER = new LocationSerializer(", ");
     public static final ISerializer<Location, String> LOCATION_SERIALIZER = new LocationSerializer(",");
     public static final ISerializer<BlockPosition, String> BLOCK_POSITION_SERIALIZER = BlockPositionSerializer.getInstance();

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/serialization/impl/LocationSerializer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/serialization/impl/LocationSerializer.java
@@ -11,9 +11,16 @@ import org.bukkit.Location;
 public class LocationSerializer implements ISerializer<Location, String> {
 
     private final String separator;
+    private final boolean center;
 
     public LocationSerializer(String separator) {
         this.separator = separator;
+        this.center = false;
+    }
+
+    public LocationSerializer(String separator, boolean center) {
+        this.separator = separator;
+        this.center = center;
     }
 
     @NotNull
@@ -37,10 +44,15 @@ public class LocationSerializer implements ISerializer<Location, String> {
             String[] sections = element.split(separator);
 
             double x = Double.parseDouble(sections[1]);
+            if (center && !sections[1].contains(".")) x += 0.5;
+
             double y = Double.parseDouble(sections[2]);
+
             double z = Double.parseDouble(sections[3]);
+            if (center && !sections[3].contains(".")) z += 0.5;
+
             float yaw = sections.length > 5 ? Float.parseFloat(sections[4]) : 0;
-            float pitch = sections.length > 4 ? Float.parseFloat(sections[5]) : 0;
+            float pitch = sections.length > 6 ? Float.parseFloat(sections[5]) : 0;
 
             return new LazyWorldLocation(sections[0], x, y, z, yaw, pitch);
         } catch (Exception error) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SpawnIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SpawnIsland.java
@@ -144,7 +144,7 @@ public class SpawnIsland implements Island {
 
     public SpawnIsland() throws ManagerLoadException {
         String spawnLocation = plugin.getSettings().getSpawn().getLocation();
-        Location centerLocation = Serializers.LOCATION_SPACED_SERIALIZER.deserialize(spawnLocation);
+        Location centerLocation = Serializers.LOCATION_SPACED_CENTERED_SERIALIZER.deserialize(spawnLocation);
         if (centerLocation == null) {
             throw new ManagerLoadException("The spawn location could not be parsed", ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
         }


### PR DESCRIPTION
This is to fix the issue #2772 , from now on, when x and y locations in config do not have '.', 0.5 is added to them to center locations set on older plugin versions and those set by default in config.

Additionally, I fixed the location pitch loading because it was incorrectly checking the section length.

And I've implemented the same thing in island previews, to standarize it.