### PR TITLE
Prevent non-island members from editing warps

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuWarpCategories.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuWarpCategories.java
@@ -79,7 +79,8 @@ public class MenuWarpCategories extends AbstractPagedMenu<MenuWarpCategories.Vie
                        Menu<View, IslandViewArgs> menu, IslandViewArgs args) {
             super(inventoryViewer, previousMenuView, menu);
             this.island = args.getIsland();
-            this.hasManagePerms = island.hasPermission(inventoryViewer, IslandPrivileges.SET_WARP);
+            this.hasManagePerms = island.isMember(inventoryViewer) &&
+                    island.hasPermission(inventoryViewer, IslandPrivileges.SET_WARP);
         }
 
         @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuWarps.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuWarps.java
@@ -103,7 +103,8 @@ public class MenuWarps extends AbstractPagedMenu<MenuWarps.View, MenuWarps.Args,
             super(inventoryViewer, previousMenuView, menu);
             this.island = args.getIsland();
             this.warpCategory = args.warpCategory;
-            this.hasManagePerms = warpCategory.getIsland().hasPermission(inventoryViewer, IslandPrivileges.SET_WARP);
+            this.hasManagePerms = warpCategory.getIsland().isMember(inventoryViewer) &&
+                    warpCategory.getIsland().hasPermission(inventoryViewer, IslandPrivileges.SET_WARP);
         }
 
         @Override


### PR DESCRIPTION
Players who were not members of the island but had ALL permission, could edit warps, although it is a Command Privilege, so only members should have access to it.