### PR TITLE
Fix ratings formatting in the ratings menu title

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandRatings.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandRatings.java
@@ -8,6 +8,7 @@ import com.bgsoftware.superiorskyblock.api.menu.Menu;
 import com.bgsoftware.superiorskyblock.api.menu.view.MenuView;
 import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.core.SequentialListBuilder;
+import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.io.MenuParserImpl;
 import com.bgsoftware.superiorskyblock.core.menu.AbstractPagedMenu;
 import com.bgsoftware.superiorskyblock.core.menu.MenuIdentifiers;
@@ -71,7 +72,7 @@ public class MenuIslandRatings extends AbstractPagedMenu<MenuIslandRatings.View,
 
         @Override
         public String replaceTitle(String title) {
-            return title.replace("{0}", String.valueOf(island.getTotalRating()));
+            return title.replace("{0}", Formatters.NUMBER_FORMATTER.format(island.getTotalRating()));
         }
 
         @Override


### PR DESCRIPTION
To eliminate such situations:
<img width="862" height="156" alt="image" src="https://github.com/user-attachments/assets/248198c1-ab8d-4aca-b965-f6d657732c27" />
