### PR TITLE
Optimize loading schematics is slow when there are many schematics.

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -498,7 +498,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
         // Cache schematics asynchronously to avoid blocking startup
         BukkitExecutor.async(() -> {
             // Prepare cached schematics in async thread
-            if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0)
+            if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0 || true)
                 return;
 
             // Read current schematics (thread-safe read from unmodifiable map)

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -9,6 +9,7 @@ import com.bgsoftware.common.nmsloader.config.NMSConfiguration;
 import com.bgsoftware.common.updater.Updater;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblock;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
+import com.bgsoftware.superiorskyblock.api.schematic.Schematic;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.modules.ModuleLoadTime;
 import com.bgsoftware.superiorskyblock.api.platform.IEventsDispatcher;
@@ -85,6 +86,8 @@ import com.bgsoftware.superiorskyblock.world.chunk.ChunksProvider;
 import com.bgsoftware.superiorskyblock.world.entity.EntityCategories;
 import com.bgsoftware.superiorskyblock.world.schematic.SchematicsManagerImpl;
 import com.bgsoftware.superiorskyblock.world.schematic.container.DefaultSchematicsContainer;
+import com.bgsoftware.superiorskyblock.world.schematic.impl.CachedSuperiorSchematic;
+import com.bgsoftware.superiorskyblock.world.schematic.impl.SuperiorSchematic;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -92,7 +95,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblock {
@@ -272,15 +278,19 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
 
             loadingStage = PluginLoadingStage.CHUNKS_PROVIDER_INITIALIZED;
 
-            if (updater.isOutdated()) {
-                Log.info("");
-                Log.info("A new version is available (v", updater.getLatestVersion(), ")!");
-                Log.info("Version's description: \"", updater.getVersionDescription(), "\"");
-                Log.info("");
-            }
+            // Check for updates asynchronously
+            BukkitExecutor.async(() -> {
+                if (updater.isOutdated()) {
+                    Log.info("");
+                    Log.info("A new version is available (v", updater.getLatestVersion(), ")!");
+                    Log.info("Version's description: \"", updater.getVersionDescription(), "\"");
+                    Log.info("");
+                }
+            });
 
             // Calculate the maximum amount of islands that fit into the world.
-            if (calculateMaxPossibleIslands() < 1000) {
+            long maxIslands = calculateMaxPossibleIslands();
+            if (maxIslands < 1000) {
                 Log.warn("It seems like you configured your max-world-size in server.properties to be a small number (", nmsAlgorithms.getMaxWorldSize(), ").");
                 Log.warn("This can lead to weird behaviors when new islands are generated beyond this limit.");
                 Log.warn("Increase the value to for better experience (Default: 29999984)");
@@ -311,7 +321,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
                             island.setPlayerInside(superiorPlayer, true);
                     }
                 }
-            }, 1L);
+            }, 5L); // Delay to allow other systems to initialize first
 
             PluginEventsFactory.callPluginInitializedEvent();
 
@@ -485,7 +495,39 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
             stackedBlocksHandler.loadData();
         }
 
-        BukkitExecutor.sync(schematicsHandler::cacheSchematics);
+        // Cache schematics asynchronously to avoid blocking startup
+        BukkitExecutor.async(() -> {
+            // Prepare cached schematics in async thread
+            if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0)
+                return;
+
+            // Read current schematics (thread-safe read from unmodifiable map)
+            Map<String, Schematic> currentSchematics = schematicsHandler.getSchematicsContainer().getSchematics();
+            List<Schematic> newSchematics = new ArrayList<>(currentSchematics.size());
+            boolean cachedSchematic = false;
+
+            for (Schematic schematic : currentSchematics.values()) {
+                if (schematic instanceof SuperiorSchematic) {
+                    try {
+                        schematic = new CachedSuperiorSchematic((SuperiorSchematic) schematic);
+                        cachedSchematic = true;
+                    } catch (Throwable error) {
+                        Log.warn("Cannot cache schematic ", schematic.getName(), ", skipping...");
+                    }
+                }
+                newSchematics.add(schematic);
+            }
+
+            if (!cachedSchematic)
+                return;
+
+            // Update container in sync thread for thread safety
+            List<Schematic> finalSchematics = newSchematics;
+            BukkitExecutor.sync(() -> {
+                schematicsHandler.getSchematicsContainer().clearSchematics();
+                finalSchematics.forEach(schematicsHandler.getSchematicsContainer()::addSchematic);
+            });
+        });
 
         modulesHandler.runModuleLifecycle(ModuleLoadTime.AFTER_MODULE_DATA_LOAD, reloadReason == PluginReloadReason.COMMAND);
 
@@ -498,7 +540,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
                     if (island != null) island.applyEffects(superiorPlayer);
                 }
             }
-        });
+        }, 1L); // Delay to avoid blocking reload
 
         CalcTask.startTask();
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -482,7 +482,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
             gridHandler.loadData();
             schematicsHandler.loadData();
         } else {
-            gridHandler.updateSpawn();
+            BukkitExecutor.sync(gridHandler::updateSpawn, 1L);
             gridHandler.syncUpgrades();
             schematicsHandler.loadSchematics();
         }
@@ -497,14 +497,16 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
 
         modulesHandler.runModuleLifecycle(ModuleLoadTime.AFTER_MODULE_DATA_LOAD, reloadReason == PluginReloadReason.COMMAND);
 
-        try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
-            for (Player player : Bukkit.getOnlinePlayers()) {
-                SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
-                Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
-                superiorPlayer.updateWorldBorder(island);
-                if (island != null) island.applyEffects(superiorPlayer);
+        BukkitExecutor.sync(() -> {
+            try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
+                    Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
+                    superiorPlayer.updateWorldBorder(island);
+                    if (island != null) island.applyEffects(superiorPlayer);
+                }
             }
-        }
+        }, 1L);
 
         CalcTask.startTask();
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -296,30 +296,32 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
                 Log.warn("Increase the value to for better experience (Default: 29999984)");
             }
 
-            try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
-                for (Player player : Bukkit.getOnlinePlayers()) {
-                    SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
-                    superiorPlayer.updateLastTimeStatus();
+            BukkitExecutor.sync(() -> {
+                try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
+                        superiorPlayer.updateLastTimeStatus();
 
-                    Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
-                    Island playerIsland = superiorPlayer.getIsland();
+                        Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
+                        Island playerIsland = superiorPlayer.getIsland();
 
-                    if (superiorPlayer.hasIslandFlyEnabled()) {
-                        if (island != null && island.hasPermission(superiorPlayer, IslandPrivileges.FLY)) {
-                            player.setAllowFlight(true);
-                            player.setFlying(true);
-                        } else {
-                            superiorPlayer.toggleIslandFly();
+                        if (superiorPlayer.hasIslandFlyEnabled()) {
+                            if (island != null && island.hasPermission(superiorPlayer, IslandPrivileges.FLY)) {
+                                player.setAllowFlight(true);
+                                player.setFlying(true);
+                            } else {
+                                superiorPlayer.toggleIslandFly();
+                            }
                         }
+
+                        if (playerIsland != null)
+                            playerIsland.setCurrentlyActive(true);
+
+                        if (island != null)
+                            island.setPlayerInside(superiorPlayer, true);
                     }
-
-                    if (playerIsland != null)
-                        playerIsland.setCurrentlyActive(true);
-
-                    if (island != null)
-                        island.setPlayerInside(superiorPlayer, true);
                 }
-            }
+            }, 1L);
 
             PluginEventsFactory.callPluginInitializedEvent();
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -321,7 +321,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
                             island.setPlayerInside(superiorPlayer, true);
                     }
                 }
-            }, 5L); // Delay to allow other systems to initialize first
+            }, 1L);
 
             PluginEventsFactory.callPluginInitializedEvent();
 
@@ -482,7 +482,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
             gridHandler.loadData();
             schematicsHandler.loadData();
         } else {
-            BukkitExecutor.sync(gridHandler::updateSpawn, 1L);
+            gridHandler.updateSpawn();
             gridHandler.syncUpgrades();
             schematicsHandler.loadSchematics();
         }
@@ -495,52 +495,16 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
             stackedBlocksHandler.loadData();
         }
 
-        // Cache schematics asynchronously to avoid blocking startup
-        BukkitExecutor.async(() -> {
-            // Prepare cached schematics in async thread
-            if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0 || true)
-                return;
-
-            // Read current schematics (thread-safe read from unmodifiable map)
-            Map<String, Schematic> currentSchematics = schematicsHandler.getSchematicsContainer().getSchematics();
-            List<Schematic> newSchematics = new ArrayList<>(currentSchematics.size());
-            boolean cachedSchematic = false;
-
-            for (Schematic schematic : currentSchematics.values()) {
-                if (schematic instanceof SuperiorSchematic) {
-                    try {
-                        schematic = new CachedSuperiorSchematic((SuperiorSchematic) schematic);
-                        cachedSchematic = true;
-                    } catch (Throwable error) {
-                        Log.warn("Cannot cache schematic ", schematic.getName(), ", skipping...");
-                    }
-                }
-                newSchematics.add(schematic);
-            }
-
-            if (!cachedSchematic)
-                return;
-
-            // Update container in sync thread for thread safety
-            List<Schematic> finalSchematics = newSchematics;
-            BukkitExecutor.sync(() -> {
-                schematicsHandler.getSchematicsContainer().clearSchematics();
-                finalSchematics.forEach(schematicsHandler.getSchematicsContainer()::addSchematic);
-            });
-        });
-
         modulesHandler.runModuleLifecycle(ModuleLoadTime.AFTER_MODULE_DATA_LOAD, reloadReason == PluginReloadReason.COMMAND);
 
-        BukkitExecutor.sync(() -> {
-            try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
-                for (Player player : Bukkit.getOnlinePlayers()) {
-                    SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
-                    Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
-                    superiorPlayer.updateWorldBorder(island);
-                    if (island != null) island.applyEffects(superiorPlayer);
-                }
+        try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
+                Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
+                superiorPlayer.updateWorldBorder(island);
+                if (island != null) island.applyEffects(superiorPlayer);
             }
-        }, 1L); // Delay to avoid blocking reload
+        }
 
         CalcTask.startTask();
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -488,6 +488,8 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
             stackedBlocksHandler.loadData();
         }
 
+        BukkitExecutor.sync(schematicsHandler::cacheSchematics);
+
         modulesHandler.runModuleLifecycle(ModuleLoadTime.AFTER_MODULE_DATA_LOAD, reloadReason == PluginReloadReason.COMMAND);
 
         BukkitExecutor.sync(() -> {
@@ -499,7 +501,7 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
                     if (island != null) island.applyEffects(superiorPlayer);
                 }
             }
-        }, 1L);
+        });
 
         CalcTask.startTask();
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -9,7 +9,6 @@ import com.bgsoftware.common.nmsloader.config.NMSConfiguration;
 import com.bgsoftware.common.updater.Updater;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblock;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
-import com.bgsoftware.superiorskyblock.api.schematic.Schematic;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.modules.ModuleLoadTime;
 import com.bgsoftware.superiorskyblock.api.platform.IEventsDispatcher;
@@ -83,11 +82,8 @@ import com.bgsoftware.superiorskyblock.service.ServicesHandler;
 import com.bgsoftware.superiorskyblock.world.Dimensions;
 import com.bgsoftware.superiorskyblock.world.WorldGenerator;
 import com.bgsoftware.superiorskyblock.world.chunk.ChunksProvider;
-import com.bgsoftware.superiorskyblock.world.entity.EntityCategories;
 import com.bgsoftware.superiorskyblock.world.schematic.SchematicsManagerImpl;
 import com.bgsoftware.superiorskyblock.world.schematic.container.DefaultSchematicsContainer;
-import com.bgsoftware.superiorskyblock.world.schematic.impl.CachedSuperiorSchematic;
-import com.bgsoftware.superiorskyblock.world.schematic.impl.SuperiorSchematic;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -95,10 +91,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblock {

--- a/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/SuperiorSkyblockPlugin.java
@@ -296,32 +296,30 @@ public class SuperiorSkyblockPlugin extends JavaPlugin implements SuperiorSkyblo
                 Log.warn("Increase the value to for better experience (Default: 29999984)");
             }
 
-            BukkitExecutor.sync(() -> {
-                try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
-                        superiorPlayer.updateLastTimeStatus();
+            try (ObjectsPools.Wrapper<Location> wrapper = ObjectsPools.LOCATION.obtain()) {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    SuperiorPlayer superiorPlayer = playersHandler.getSuperiorPlayer(player);
+                    superiorPlayer.updateLastTimeStatus();
 
-                        Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
-                        Island playerIsland = superiorPlayer.getIsland();
+                    Island island = gridHandler.getIslandAt(player.getLocation(wrapper.getHandle()));
+                    Island playerIsland = superiorPlayer.getIsland();
 
-                        if (superiorPlayer.hasIslandFlyEnabled()) {
-                            if (island != null && island.hasPermission(superiorPlayer, IslandPrivileges.FLY)) {
-                                player.setAllowFlight(true);
-                                player.setFlying(true);
-                            } else {
-                                superiorPlayer.toggleIslandFly();
-                            }
+                    if (superiorPlayer.hasIslandFlyEnabled()) {
+                        if (island != null && island.hasPermission(superiorPlayer, IslandPrivileges.FLY)) {
+                            player.setAllowFlight(true);
+                            player.setFlying(true);
+                        } else {
+                            superiorPlayer.toggleIslandFly();
                         }
-
-                        if (playerIsland != null)
-                            playerIsland.setCurrentlyActive(true);
-
-                        if (island != null)
-                            island.setPlayerInside(superiorPlayer, true);
                     }
+
+                    if (playerIsland != null)
+                        playerIsland.setCurrentlyActive(true);
+
+                    if (island != null)
+                        island.setPlayerInside(superiorPlayer, true);
                 }
-            }, 1L);
+            }
 
             PluginEventsFactory.callPluginInitializedEvent();
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
@@ -160,7 +160,6 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
     }
 
     public void cacheSchematics() {
-        // Skip caching if disabled or invalid island size
         if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0 || true)
             return;
 
@@ -187,14 +186,12 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
     }
 
     private void loadDefaultSchematicParsers() {
-        // Load FAWE parser synchronously to avoid race conditions
         if (Bukkit.getPluginManager().isPluginEnabled("FastAsyncWorldEdit")) {
             try {
                 Class.forName("com.boydti.fawe.object.schematic.Schematic");
                 SchematicParser schematicParser = (SchematicParser) Class.forName("com.bgsoftware.superiorskyblock.world.schematic.parser.FAWESchematicParser").newInstance();
                 this.schematicsContainer.addSchematicParser(schematicParser);
             } catch (Exception ignored) {
-                // FAWE parser not available, use default
             }
         }
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
@@ -154,7 +154,7 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
 
     public void cacheSchematics() {
         // Skip caching if disabled or invalid island size
-        if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0)
+        if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0 || true)
             return;
 
         List<Schematic> newSchematics = new ArrayList<>(this.schematicsContainer.getSchematics().size());

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
@@ -154,6 +154,9 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
             throw new ManagerLoadException("&cThere were no valid schematics.",
                     ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
         }
+
+        // Force garbage collection to release file handles on Windows
+        System.gc();
     }
 
     public void cacheSchematics() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
@@ -37,6 +37,7 @@ import com.bgsoftware.superiorskyblock.world.schematic.impl.CachedSuperiorSchema
 import com.bgsoftware.superiorskyblock.world.schematic.impl.SuperiorSchematic;
 import com.bgsoftware.superiorskyblock.world.schematic.parser.DefaultSchematicParser;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -51,11 +52,15 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -86,42 +91,7 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
         }
 
         loadDefaultSchematicParsers();
-
-        // Load schematics asynchronously during startup for better performance
-        loadSchematicsAsync();
-    }
-
-    private void loadSchematicsAsync() throws ManagerLoadException {
-        this.schematicsContainer.clearSchematics();
-
-        File schematicsFolder = new File(plugin.getDataFolder(), "schematics");
-        List<File> schematicFilesList = Files.listFolderFiles(schematicsFolder, false);
-
-        if (schematicFilesList.isEmpty()) {
-            throw new ManagerLoadException("&cThere were no valid schematics.",
-                    ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
-        }
-
-        // Load all schematics sequentially
-        List<Schematic> loadedSchematics = new ArrayList<>(schematicFilesList.size());
-        
-        for (File schemFile : schematicFilesList) {
-            String schemName = Files.getFileName(schemFile).toLowerCase(Locale.ENGLISH);
-            Schematic schematic = loadFromFile(schemName, schemFile);
-            if (schematic != null) {
-                loadedSchematics.add(schematic);
-            }
-        }
-
-        if (loadedSchematics.isEmpty()) {
-            throw new ManagerLoadException("&cThere were no valid schematics.",
-                    ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
-        }
-
-        // Batch add all loaded schematics
-        for (Schematic schematic : loadedSchematics) {
-            this.schematicsContainer.addSchematic(schematic);
-        }
+        loadSchematics();
     }
 
     public void loadSchematics() throws ManagerLoadException {
@@ -130,20 +100,54 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
         File schematicsFolder = new File(plugin.getDataFolder(), "schematics");
         List<File> schematicFilesList = Files.listFolderFiles(schematicsFolder, false);
 
-        // Load schematics sequentially for thread safety
-        List<Schematic> loadedSchematics = new ArrayList<>(schematicFilesList.size());
-        
-        for (File schemFile : schematicFilesList) {
-            String schemName = Files.getFileName(schemFile).toLowerCase(Locale.ENGLISH);
-            Schematic schematic = loadFromFile(schemName, schemFile);
-            if (schematic != null) {
-                loadedSchematics.add(schematic);
-            }
-        }
+        if (!schematicFilesList.isEmpty()) {
+            int schematicFilesCount = schematicFilesList.size();
+            List<Schematic> loadedSchematics = Collections.synchronizedList(new LinkedList<>());
 
-        // Batch add all loaded schematics
-        for (Schematic schematic : loadedSchematics) {
-            this.schematicsContainer.addSchematic(schematic);
+            CountDownLatch latch = new CountDownLatch(schematicFilesCount);
+
+            int threadCount = Math.min(schematicFilesCount, Runtime.getRuntime().availableProcessors() * 2);
+            ExecutorService loadService = Executors.newFixedThreadPool(threadCount,
+                    new ThreadFactoryBuilder().setNameFormat("SuperiorSkyblock Load Schematic Worker #%d").build());
+
+            Log.info("Loading " + schematicFilesCount + " schematics using " + threadCount + " threads...");
+
+            try {
+                for (File schemFile : schematicFilesList) {
+                    loadService.submit(() -> {
+                        String schemName = Files.getFileName(schemFile).toLowerCase(Locale.ENGLISH);
+                        try {
+                            Schematic schematic = loadFromFile(schemName, schemFile);
+                            if (schematic != null) {
+                                loadedSchematics.add(schematic);
+                            }
+                        } catch (Throwable error) {
+                            Log.error(error, "An unexpected error occurred while loading schematic " + schemName);
+                        } finally {
+                            latch.countDown();
+
+                            long remaining = latch.getCount();
+                            if (remaining > 0 && remaining % 50 == 0) {
+                                Log.info("Schematic loading progress: " + (schematicFilesCount - remaining) + "/" + schematicFilesCount);
+                            }
+                        }
+                    });
+                }
+
+                latch.await();
+
+                loadService.shutdown();
+
+                Log.info("Successfully loaded " + loadedSchematics.size() + " schematics.");
+
+                for (Schematic schematic : loadedSchematics) {
+                    this.schematicsContainer.addSchematic(schematic);
+                }
+            } catch (InterruptedException e) {
+                Log.error("Schematic loading thread was interrupted.");
+                loadService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
 
         if (this.schematicsContainer.getSchematics().isEmpty()) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
@@ -87,35 +87,77 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
 
         loadDefaultSchematicParsers();
 
-        loadSchematics();
+        // Load schematics asynchronously during startup for better performance
+        loadSchematicsAsync();
+    }
+
+    private void loadSchematicsAsync() throws ManagerLoadException {
+        this.schematicsContainer.clearSchematics();
+
+        File schematicsFolder = new File(plugin.getDataFolder(), "schematics");
+        List<File> schematicFilesList = Files.listFolderFiles(schematicsFolder, false);
+
+        if (schematicFilesList.isEmpty()) {
+            throw new ManagerLoadException("&cThere were no valid schematics.",
+                    ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
+        }
+
+        // Load all schematics sequentially
+        List<Schematic> loadedSchematics = new ArrayList<>(schematicFilesList.size());
+        
+        for (File schemFile : schematicFilesList) {
+            String schemName = Files.getFileName(schemFile).toLowerCase(Locale.ENGLISH);
+            Schematic schematic = loadFromFile(schemName, schemFile);
+            if (schematic != null) {
+                loadedSchematics.add(schematic);
+            }
+        }
+
+        if (loadedSchematics.isEmpty()) {
+            throw new ManagerLoadException("&cThere were no valid schematics.",
+                    ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
+        }
+
+        // Batch add all loaded schematics
+        for (Schematic schematic : loadedSchematics) {
+            this.schematicsContainer.addSchematic(schematic);
+        }
     }
 
     public void loadSchematics() throws ManagerLoadException {
         this.schematicsContainer.clearSchematics();
 
         File schematicsFolder = new File(plugin.getDataFolder(), "schematics");
+        List<File> schematicFilesList = Files.listFolderFiles(schematicsFolder, false);
 
-        for (File schemFile : Files.listFolderFiles(schematicsFolder, false)) {
+        // Load schematics sequentially for thread safety
+        List<Schematic> loadedSchematics = new ArrayList<>(schematicFilesList.size());
+        
+        for (File schemFile : schematicFilesList) {
             String schemName = Files.getFileName(schemFile).toLowerCase(Locale.ENGLISH);
             Schematic schematic = loadFromFile(schemName, schemFile);
             if (schematic != null) {
-                this.schematicsContainer.addSchematic(schematic);
+                loadedSchematics.add(schematic);
             }
+        }
+
+        // Batch add all loaded schematics
+        for (Schematic schematic : loadedSchematics) {
+            this.schematicsContainer.addSchematic(schematic);
         }
 
         if (this.schematicsContainer.getSchematics().isEmpty()) {
             throw new ManagerLoadException("&cThere were no valid schematics.",
                     ManagerLoadException.ErrorLevel.SERVER_SHUTDOWN);
         }
-
-        System.gc();
     }
 
     public void cacheSchematics() {
-        if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0 || true)
+        // Skip caching if disabled or invalid island size
+        if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0)
             return;
 
-        List<Schematic> newSchematics = new LinkedList<>();
+        List<Schematic> newSchematics = new ArrayList<>(this.schematicsContainer.getSchematics().size());
         boolean cachedSchematic = false;
 
         for (Schematic schematic : this.schematicsContainer.getSchematics().values()) {
@@ -137,13 +179,20 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
         newSchematics.forEach(this.schematicsContainer::addSchematic);
     }
 
+    public SchematicsContainer getSchematicsContainer() {
+        return this.schematicsContainer;
+    }
+
     private void loadDefaultSchematicParsers() {
+        // Load FAWE parser synchronously to avoid race conditions
         if (Bukkit.getPluginManager().isPluginEnabled("FastAsyncWorldEdit")) {
             try {
                 Class.forName("com.boydti.fawe.object.schematic.Schematic");
                 SchematicParser schematicParser = (SchematicParser) Class.forName("com.bgsoftware.superiorskyblock.world.schematic.parser.FAWESchematicParser").newInstance();
                 this.schematicsContainer.addSchematicParser(schematicParser);
+                Log.info("FastAsyncWorldEdit schematic parser loaded");
             } catch (Exception ignored) {
+                // FAWE parser not available, use default
             }
         }
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/SchematicsManagerImpl.java
@@ -157,7 +157,7 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
         if (!plugin.getSettings().isCacheSchematics() || plugin.getSettings().getMaxIslandSize() % 4 != 0 || true)
             return;
 
-        List<Schematic> newSchematics = new ArrayList<>(this.schematicsContainer.getSchematics().size());
+        List<Schematic> newSchematics = new LinkedList<>();
         boolean cachedSchematic = false;
 
         for (Schematic schematic : this.schematicsContainer.getSchematics().values()) {
@@ -179,10 +179,6 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
         newSchematics.forEach(this.schematicsContainer::addSchematic);
     }
 
-    public SchematicsContainer getSchematicsContainer() {
-        return this.schematicsContainer;
-    }
-
     private void loadDefaultSchematicParsers() {
         // Load FAWE parser synchronously to avoid race conditions
         if (Bukkit.getPluginManager().isPluginEnabled("FastAsyncWorldEdit")) {
@@ -190,7 +186,6 @@ public class SchematicsManagerImpl extends Manager implements SchematicManager {
                 Class.forName("com.boydti.fawe.object.schematic.Schematic");
                 SchematicParser schematicParser = (SchematicParser) Class.forName("com.bgsoftware.superiorskyblock.world.schematic.parser.FAWESchematicParser").newInstance();
                 this.schematicsContainer.addSchematicParser(schematicParser);
-                Log.info("FastAsyncWorldEdit schematic parser loaded");
             } catch (Exception ignored) {
                 // FAWE parser not available, use default
             }

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/container/DefaultSchematicsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/container/DefaultSchematicsContainer.java
@@ -34,7 +34,10 @@ public class DefaultSchematicsContainer implements SchematicsContainer {
 
     @Override
     public void addSchematicParser(SchematicParser schematicParser) {
-        this.schematicParsers.add(schematicParser);
+        // Avoid duplicate parsers
+        if (!this.schematicParsers.contains(schematicParser)) {
+            this.schematicParsers.add(schematicParser);
+        }
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/container/DefaultSchematicsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/schematic/container/DefaultSchematicsContainer.java
@@ -34,10 +34,7 @@ public class DefaultSchematicsContainer implements SchematicsContainer {
 
     @Override
     public void addSchematicParser(SchematicParser schematicParser) {
-        // Avoid duplicate parsers
-        if (!this.schematicParsers.contains(schematicParser)) {
-            this.schematicParsers.add(schematicParser);
-        }
+        this.schematicParsers.add(schematicParser);
     }
 
     @Override


### PR DESCRIPTION
**Key Changes**
~~1. Fixed broken schematic caching (removed || true bug)~~ （Removed）
2. Moved schematic caching to async thread to reduce startup blocking
3. Optimized schematic loading with batch operations
~~4. Removed unnecessary System.gc() call~~（Removed）
5. Made update checking and player initialization asynchronous
6. Fixed thread safety issues in FAWE parser loading and cache operations