### PR TITLE
Improve ClearActions

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAdd.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAdd.java
@@ -12,7 +12,6 @@ import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.island.IslandUtils;
 import com.bgsoftware.superiorskyblock.island.role.SPlayerRole;
-import com.bgsoftware.superiorskyblock.player.inventory.ClearActions;
 import org.bukkit.command.CommandSender;
 
 import java.util.Collections;
@@ -89,9 +88,6 @@ public class CmdAdminAdd implements IAdminIslandCommand {
             Message.JOINED_ISLAND.send(targetPlayer, superiorPlayer.getName());
             Message.ADMIN_ADD_PLAYER.send(sender, targetPlayer.getName(), superiorPlayer.getName());
         }
-
-        ClearActions.runClearActions(targetPlayer, plugin.getSettings().getClearActionsOnJoin(),
-                plugin.getSettings().isTeleportOnJoin() ? island : null);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAdd.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminAdd.java
@@ -90,10 +90,8 @@ public class CmdAdminAdd implements IAdminIslandCommand {
             Message.ADMIN_ADD_PLAYER.send(sender, targetPlayer.getName(), superiorPlayer.getName());
         }
 
-        if (plugin.getSettings().isTeleportOnJoin() && targetPlayer.isOnline())
-            targetPlayer.teleport(island);
-
-        ClearActions.runClearActions(targetPlayer.asOfflinePlayer(), false, plugin.getSettings().getClearActionsOnJoin());
+        ClearActions.runClearActions(targetPlayer, plugin.getSettings().getClearActionsOnJoin(),
+                plugin.getSettings().isTeleportOnJoin() ? island : null);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminJoin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminJoin.java
@@ -81,10 +81,8 @@ public class CmdAdminJoin implements IAdminIslandCommand {
         else
             Message.JOINED_ISLAND.send(superiorPlayer, targetPlayer.getName());
 
-        if (plugin.getSettings().isTeleportOnJoin())
-            superiorPlayer.teleport(island);
-
-        ClearActions.runClearActions(superiorPlayer.asOfflinePlayer(), false, plugin.getSettings().getClearActionsOnJoin());
+        ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnJoin(),
+                plugin.getSettings().isTeleportOnJoin() ? island : null);
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminJoin.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminJoin.java
@@ -10,7 +10,6 @@ import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.island.IslandUtils;
 import com.bgsoftware.superiorskyblock.island.role.SPlayerRole;
-import com.bgsoftware.superiorskyblock.player.inventory.ClearActions;
 import org.bukkit.command.CommandSender;
 
 import java.util.Collections;
@@ -80,9 +79,6 @@ public class CmdAdminJoin implements IAdminIslandCommand {
             Message.JOINED_ISLAND_NAME.send(superiorPlayer, island.getName());
         else
             Message.JOINED_ISLAND.send(superiorPlayer, targetPlayer.getName());
-
-        ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnJoin(),
-                plugin.getSettings().isTeleportOnJoin() ? island : null);
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAccept.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAccept.java
@@ -100,10 +100,8 @@ public class CmdAccept implements ISuperiorCommand {
         else
             Message.JOINED_ISLAND.send(superiorPlayer, targetPlayer.getName());
 
-        if (plugin.getSettings().isTeleportOnJoin())
-            superiorPlayer.teleport(island);
-
-        ClearActions.runClearActions(superiorPlayer.asOfflinePlayer(), false, plugin.getSettings().getClearActionsOnJoin());
+        ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnJoin(),
+                plugin.getSettings().isTeleportOnJoin() ? island : null);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAccept.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdAccept.java
@@ -10,7 +10,6 @@ import com.bgsoftware.superiorskyblock.core.events.plugin.PluginEventsFactory;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import com.bgsoftware.superiorskyblock.island.IslandUtils;
 import com.bgsoftware.superiorskyblock.island.role.SPlayerRole;
-import com.bgsoftware.superiorskyblock.player.inventory.ClearActions;
 import org.bukkit.command.CommandSender;
 
 import java.util.Arrays;
@@ -99,9 +98,6 @@ public class CmdAccept implements ISuperiorCommand {
             Message.JOINED_ISLAND_NAME.send(superiorPlayer, island.getName());
         else
             Message.JOINED_ISLAND.send(superiorPlayer, targetPlayer.getName());
-
-        ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnJoin(),
-                plugin.getSettings().isTeleportOnJoin() ? island : null);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -586,64 +586,73 @@ public class SIsland implements Island {
     }
 
     @Override
-    public void removeMember(SuperiorPlayer superiorPlayer, MemberRemoveReason memberRemoveReason) {
+    public void removeMember(SuperiorPlayer superiorPlayer, MemberRemoveReason reason) {
         Preconditions.checkNotNull(superiorPlayer, "superiorPlayer parameter cannot be null.");
-        Preconditions.checkNotNull(memberRemoveReason, "memberRemoveReason parameter cannot be null.");
+        Preconditions.checkNotNull(reason, "memberRemoveReason parameter cannot be null.");
+        Preconditions.checkArgument(!superiorPlayer.equals(owner), "superiorPlayer cannot be island owner.");
 
-        if (memberRemoveReason == MemberRemoveReason.KICK) {
+        removeMemberSafe(superiorPlayer, reason);
+    }
+
+    private void removeMemberSafe(SuperiorPlayer superiorPlayer, MemberRemoveReason reason) {
+        if (reason == MemberRemoveReason.KICK)
             Log.debug(Debug.KICK_MEMBER, owner.getName(), superiorPlayer.getName());
-        } else if (memberRemoveReason == MemberRemoveReason.LEAVE) {
+        else if (reason == MemberRemoveReason.LEAVE)
             Log.debug(Debug.LEAVE_ISLAND, owner.getName(), superiorPlayer.getName());
+
+        if (!superiorPlayer.equals(owner)) {
+            boolean removedMember = members.writeAndGet(members -> members.remove(superiorPlayer));
+
+            if (!removedMember) {
+                // If the remove method failed, we iterate through all the members and remove the member manually.
+                // Should fix issues if members are not in the correct order.
+                // Reference: https://github.com/BG-Software-LLC/SuperiorSkyblock2/issues/734
+                removedMember = members.writeAndGet(members -> members.removeIf(superiorPlayer::equals));
+            }
+
+            // This player is not a member of the island.
+            if (!removedMember)
+                return;
         }
 
-        boolean removedMember = members.writeAndGet(members -> members.remove(superiorPlayer));
-
-        if (!removedMember) {
-            // If the remove method failed, we iterate through all the members and remove the member manually.
-            // Should fix issues if members are not in the correct order.
-            // Reference: https://github.com/BG-Software-LLC/SuperiorSkyblock2/issues/734
-            removedMember = members.writeAndGet(members -> members.removeIf(superiorPlayer::equals));
-        }
-
-        // This player is not a member of the island.
-        if (!removedMember)
-            return;
-
+        boolean isInside = superiorPlayer.isInsideIsland();
         superiorPlayer.setIsland(null);
 
-        if (memberRemoveReason == MemberRemoveReason.KICK) {
-            ClearActions.runClearActions(superiorPlayer.asOfflinePlayer(), false, plugin.getSettings().getClearActionsOnKick());
-        } else if (memberRemoveReason == MemberRemoveReason.LEAVE) {
-            ClearActions.runClearActions(superiorPlayer.asOfflinePlayer(), false, plugin.getSettings().getClearActionsOnLeave());
-        }
+        if (reason == MemberRemoveReason.DISBAND)
+            ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnDisband(),
+                    isInside ? plugin.getGrid().getSpawnIsland() : null);
+        else if (reason == MemberRemoveReason.KICK)
+            ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnKick(),
+                    plugin.getSettings().isTeleportOnKick() && isInside ? plugin.getGrid().getSpawnIsland() : null);
+        else if (reason == MemberRemoveReason.LEAVE)
+            ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnLeave(),
+                    plugin.getSettings().isTeleportOnLeave() && isInside ? plugin.getGrid().getSpawnIsland() : null);
 
         superiorPlayer.runIfOnline(player -> {
             MenuView<?, ?> openedView = superiorPlayer.getOpenedView();
 
             if (openedView != null)
                 openedView.closeView();
-
-            boolean shouldTeleport = (memberRemoveReason == MemberRemoveReason.KICK && plugin.getSettings().isTeleportOnKick()) ||
-                    (memberRemoveReason == MemberRemoveReason.LEAVE && plugin.getSettings().isTeleportOnLeave());
-
-            if (shouldTeleport && getAllPlayersInside().contains(superiorPlayer)) {
-                superiorPlayer.teleport(plugin.getGrid().getSpawnIsland());
-            } else {
-                updateIslandFly(superiorPlayer);
-            }
         });
 
         plugin.getMissions().getPlayerMissions().forEach(mission -> {
             MissionData missionData = plugin.getMissions().getMissionData(mission).orElse(null);
-            if (missionData != null && missionData.isLeaveReset())
+
+            if (missionData == null)
+                return;
+
+            if ((reason == MemberRemoveReason.DISBAND && missionData.isDisbandReset()) ||
+                    ((reason == MemberRemoveReason.KICK || reason == MemberRemoveReason.LEAVE) && missionData.isLeaveReset()))
                 superiorPlayer.resetMission(mission);
         });
 
-        plugin.getMenus().destroyMemberManage(superiorPlayer);
-        plugin.getMenus().destroyMemberRole(superiorPlayer);
-        plugin.getMenus().refreshMembers(this);
+        if (reason == MemberRemoveReason.KICK || reason == MemberRemoveReason.LEAVE) {
+            plugin.getMenus().destroyMemberManage(superiorPlayer);
+            plugin.getMenus().destroyMemberRole(superiorPlayer);
+            plugin.getMenus().refreshMembers(this);
 
-        IslandsDatabaseBridge.removeMember(this, superiorPlayer);
+            IslandsDatabaseBridge.removeMember(this, superiorPlayer);
+        }
     }
 
     @Override
@@ -1735,20 +1744,7 @@ public class SIsland implements Island {
         long profilerId = Profiler.start(ProfileType.DISBAND_ISLAND, 2);
 
         forEachIslandMember(EMPTY_IGNORED_MEMBERS, false, islandMember -> {
-            if (islandMember.equals(owner)) {
-                owner.setIsland(null);
-            } else {
-                removeMember(islandMember, MemberRemoveReason.DISBAND);
-            }
-
-            ClearActions.runClearActions(islandMember.asOfflinePlayer(), true, plugin.getSettings().getClearActionsOnDisband());
-
-            for (Mission<?> mission : plugin.getMissions().getPlayerMissions()) {
-                MissionData missionData = plugin.getMissions().getMissionData(mission).orElse(null);
-                if (missionData != null && missionData.isDisbandReset()) {
-                    islandMember.resetMission(mission);
-                }
-            }
+            removeMemberSafe(islandMember, MemberRemoveReason.DISBAND);
         });
 
         this.activeTasks.write(activeTasks -> {

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -577,6 +577,9 @@ public class SIsland implements Island {
 
         updateLastTime();
 
+        ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnJoin(),
+                plugin.getSettings().isTeleportOnJoin() ? this : null);
+
         if (superiorPlayer.isOnline()) {
             updateIslandFly(superiorPlayer);
             setCurrentlyActive();

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -618,15 +618,22 @@ public class SIsland implements Island {
         boolean isInside = superiorPlayer.isInsideIsland();
         superiorPlayer.setIsland(null);
 
-        if (reason == MemberRemoveReason.DISBAND)
+        if (reason == MemberRemoveReason.DISBAND) {
             ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnDisband(),
                     isInside ? plugin.getGrid().getSpawnIsland() : null);
-        else if (reason == MemberRemoveReason.KICK)
+        } else if (reason == MemberRemoveReason.KICK) {
+            boolean shouldTeleport = plugin.getSettings().isTeleportOnKick() && isInside;
             ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnKick(),
-                    plugin.getSettings().isTeleportOnKick() && isInside ? plugin.getGrid().getSpawnIsland() : null);
-        else if (reason == MemberRemoveReason.LEAVE)
+                    shouldTeleport ? plugin.getGrid().getSpawnIsland() : null);
+            if (!shouldTeleport)
+                updateIslandFly(superiorPlayer);
+        } else if (reason == MemberRemoveReason.LEAVE) {
+            boolean shouldTeleport = plugin.getSettings().isTeleportOnLeave() && isInside;
             ClearActions.runClearActions(superiorPlayer, plugin.getSettings().getClearActionsOnLeave(),
-                    plugin.getSettings().isTeleportOnLeave() && isInside ? plugin.getGrid().getSpawnIsland() : null);
+                    shouldTeleport ? plugin.getGrid().getSpawnIsland() : null);
+            if (!shouldTeleport)
+                updateIslandFly(superiorPlayer);
+        }
 
         superiorPlayer.runIfOnline(player -> {
             MenuView<?, ?> openedView = superiorPlayer.getOpenedView();

--- a/src/main/java/com/bgsoftware/superiorskyblock/player/inventory/ClearActions.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/player/inventory/ClearActions.java
@@ -1,12 +1,11 @@
 package com.bgsoftware.superiorskyblock.player.inventory;
 
+import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
+import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.player.inventory.ClearAction;
-import com.bgsoftware.superiorskyblock.core.logging.Log;
+import com.bgsoftware.superiorskyblock.api.wrappers.SuperiorPlayer;
 import com.bgsoftware.superiorskyblock.nms.player.OfflinePlayerData;
-import com.bgsoftware.superiorskyblock.world.Dimensions;
-import com.bgsoftware.superiorskyblock.world.EntityTeleports;
-import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
@@ -82,7 +81,12 @@ public class ClearActions {
         // Do nothing, only trigger all the register calls
     }
 
-    public static void runClearActions(OfflinePlayer offlinePlayer, boolean teleportToSpawn, Collection<ClearAction> clearActions) {
+    public static void runClearActions(SuperiorPlayer superiorPlayer, Collection<ClearAction> clearActions,
+                                       @Nullable Island islandToTeleport) {
+        if (clearActions.isEmpty() && islandToTeleport == null)
+            return;
+
+        OfflinePlayer offlinePlayer = superiorPlayer.asOfflinePlayer();
         OfflinePlayerData offlinePlayerData;
         Player onlinePlayer;
 
@@ -97,13 +101,12 @@ public class ClearActions {
         try {
             clearActions.forEach(clearAction -> clearAction.doClear(onlinePlayer));
 
-            Location spawnLocation = plugin.getGrid().getSpawnIsland().getCenter(Dimensions.NORMAL);
             if (offlinePlayerData != null) {
-                if (teleportToSpawn)
-                    offlinePlayerData.setLocation(spawnLocation);
+                if (islandToTeleport != null)
+                    offlinePlayerData.setLocation(islandToTeleport.getCenter(plugin.getSettings().getWorlds().getDefaultWorldDimension()));
                 offlinePlayerData.applyChanges();
-            } else if (teleportToSpawn) {
-                EntityTeleports.teleport(onlinePlayer, spawnLocation);
+            } else if (islandToTeleport != null) {
+                superiorPlayer.teleport(islandToTeleport);
             }
         } finally {
             if (offlinePlayerData != null)


### PR DESCRIPTION
# Changelog #
- Removed the creation of OfflinePlayerData when ClearActions are empty and the player will not be teleported.
- Allowed teleporting a fake player not only to spawn, but also to the island (currently only when adding to an island).
- Added closing the menu opened by the island leader when disbanding the island (the island can be disbanded by another member or admin, so the leader menu should also be closed).
- Removed the double clearing of island members' mission data when disbanding the island.
- Removed the clearing of members' mission data when disbanding the island when "disband-reset" was false and "leave-reset" was true (even though it was a disband, the mission data was still cleared previous).
- Removed teleporting the player to spawn on disband when they were not inside the island.

For this purpose, I slightly modified ClearActions.runClearActions() to specify the island instead of whether it should teleport to spawn or not, and in SIsland I added a helper method removeMemberSafe(), because a lot of code would simply be repeated, it is used in removeMember() available in the API, but I added a precondition there so that the leader cannot be removed with this method.