### PR TITLE
Fixes Players Without Islands Treated as Same Team (Pvp)

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/player/SSuperiorPlayer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/player/SSuperiorPlayer.java
@@ -407,7 +407,7 @@ public class SSuperiorPlayer implements SuperiorPlayer {
         World world = getWorld();
 
         // Checks for island teammates pvp
-        if (getIsland() == otherPlayer.getIsland() && (world == null || !isPvPWorldInternal(world.getName())))
+        if (getIslandLeader().equals(otherPlayer.getIslandLeader()) && (world == null || !isPvPWorldInternal(world.getName())))
             return HitActionResult.ISLAND_TEAM_PVP;
 
         // Checks if this player can bypass all pvp restrictions


### PR DESCRIPTION
Fixed an issue where players without islands were being treated as if they were on the same team (PvP).

Fixes #2873 