### PR TITLE
Fix bank logs breaking on missing position

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuBankLogs.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuBankLogs.java
@@ -101,6 +101,7 @@ public class MenuBankLogs extends AbstractPagedMenu<MenuBankLogs.View, IslandVie
 
         public void setFilteredPlayer(UUID filteredPlayer) {
             this.filteredPlayer = filteredPlayer == null ? CONSOLE_UUID : filteredPlayer;
+            this.setCurrentPage(1);
         }
 
         @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/bank/logs/CacheBankLogs.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/bank/logs/CacheBankLogs.java
@@ -21,7 +21,7 @@ public class CacheBankLogs implements IBankLogs {
 
     @Override
     public int getLastTransactionPosition() {
-        return this.transactions.readAndGet(SortedSet::size);
+        return this.transactions.readAndGet(set -> set.isEmpty() ? 0 : set.last().getPosition());
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/bank/logs/DatabaseBankLogs.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/bank/logs/DatabaseBankLogs.java
@@ -49,7 +49,13 @@ public class DatabaseBankLogs implements IBankLogs {
     @Override
     public int getLastTransactionPosition() {
         if (lastTransactionPosition == -1) {
-            lastTransactionPosition = getTransactions().size();
+            lastTransactionPosition = 0;
+            for (BankTransaction transaction : getTransactions()) {
+                int position = transaction.getPosition();
+                if (position > lastTransactionPosition) {
+                    lastTransactionPosition = position;
+                }
+            }
         }
 
         return lastTransactionPosition++;


### PR DESCRIPTION
When a new transaction was being logged, it calculated it position based on the amount of existing logs. However, when a previous log was removed (or not saved correctly), it would skip over this number, causing the position to be higher than the total amount, thus reusing the same position over and over again. This PR fixes that issue, along with automatically going back to the first page when filtering bank transactions on a user, to prevent you from seeing an empty page when filtering from a page other than the 1st.

Fix was tested before PR