### PR TITLE
Added support for setting custom biomes for islands and island worlds

### DIFF
--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_12_R1/NMSAlgorithmsImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_12_R1/NMSAlgorithmsImpl.java
@@ -21,6 +21,7 @@ import net.minecraft.server.v1_12_R1.World;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Biome;
 import org.bukkit.block.BlockState;
 import org.bukkit.command.defaults.BukkitCommand;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
@@ -39,6 +40,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 import java.util.Optional;
 
 public class NMSAlgorithmsImpl implements NMSAlgorithms {
@@ -190,6 +192,15 @@ public class NMSAlgorithmsImpl implements NMSAlgorithms {
     @Override
     public Object createMenuInventoryHolder(InventoryType inventoryType, InventoryHolder defaultHolder, String title) {
         return defaultHolder;
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_16_R3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_16_R3/NMSAlgorithmsImpl.java
@@ -32,6 +32,7 @@ import net.minecraft.server.v1_16_R3.IInventory;
 import net.minecraft.server.v1_16_R3.IRegistry;
 import net.minecraft.server.v1_16_R3.MinecraftServer;
 import net.minecraft.server.v1_16_R3.World;
+import org.bukkit.block.Biome;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -59,6 +60,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -259,6 +261,15 @@ public class NMSAlgorithmsImpl implements NMSAlgorithms {
     public Object createMenuInventoryHolder(InventoryType inventoryType, InventoryHolder defaultHolder, String title) {
         MenuCreator menuCreator = MENUS_HOLDER_CREATORS.get(inventoryType);
         return menuCreator == null ? null : menuCreator.apply(defaultHolder, title);
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_17/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_17/NMSAlgorithmsImpl.java
+++ b/NMS/v1_17/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_17/NMSAlgorithmsImpl.java
@@ -5,6 +5,7 @@ import com.bgsoftware.superiorskyblock.nms.algorithms.SpigotGlowEnchantment;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftChatMessage;
 import org.bukkit.enchantments.Enchantment;
@@ -12,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_17.AbstractNMSAlgorithms {
 
@@ -39,6 +41,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_17
         } catch (Throwable error) {
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
+        }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/NMS/v1_18/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_18/NMSAlgorithmsImpl.java
+++ b/NMS/v1_18/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_18/NMSAlgorithmsImpl.java
@@ -5,6 +5,7 @@ import com.bgsoftware.superiorskyblock.nms.algorithms.SpigotGlowEnchantment;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftChatMessage;
 import org.bukkit.enchantments.Enchantment;
@@ -12,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_18.AbstractNMSAlgorithms {
 
@@ -41,6 +43,16 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_18
             return MinecraftServer.getServer().recentTps[0];
         }
     }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
 
     private static Enchantment initializeGlowEnchantment() {
         Enchantment glowEnchant;

--- a/NMS/v1_18/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_18/NMSAlgorithmsImpl.java
+++ b/NMS/v1_18/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_18/NMSAlgorithmsImpl.java
@@ -53,7 +53,6 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_18
         }
     }
 
-
     private static Enchantment initializeGlowEnchantment() {
         Enchantment glowEnchant;
 

--- a/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
+++ b/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
@@ -7,19 +7,16 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftChatMessage;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.trim.ArmorTrim;
-import org.bukkit.inventory.meta.trim.TrimMaterial;
-import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.lang.reflect.Field;
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_19.AbstractNMSAlgorithms {
 
@@ -28,24 +25,6 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_19
     @Override
     public String parseSignLine(String original) {
         return Component.Serializer.toJson(CraftChatMessage.fromString(original)[0]);
-    }
-
-    @Override
-    public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
-        if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
-
-            if (material == null)
-                throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
-                        " into trim material, skipping...");
-            if (pattern == null)
-                throw new IllegalArgumentException("Couldn't convert " + trimPattern.toUpperCase(Locale.ENGLISH) +
-                        " into trim pattern, skipping...");
-
-            ArmorTrim armorTrim = new ArmorTrim(material, pattern);
-            armorMeta.setTrim(armorTrim);
-        }
     }
 
     @Override
@@ -66,6 +45,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_19
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
+++ b/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
@@ -49,10 +49,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_19
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
+++ b/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
@@ -49,12 +49,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_19
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
@@ -83,10 +83,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
@@ -83,12 +83,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
@@ -6,15 +6,22 @@ import com.bgsoftware.superiorskyblock.nms.v1_20_3.algorithms.SpigotGlowEnchantm
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
+import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.v1_20_R3.CraftRegistry;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftChatMessage;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20_3.AbstractNMSAlgorithms {
@@ -27,6 +34,31 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
     @Override
     public String parseSignLine(String original) {
         return Component.Serializer.toJson(CraftChatMessage.fromString(original)[0]);
+    }
+
+    @Override
+    public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
+        if (itemMeta instanceof ArmorMeta armorMeta) {
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
+
+            if (material == null)
+                throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
+                        " into trim material, skipping...");
+            if (pattern == null)
+                throw new IllegalArgumentException("Couldn't convert " + trimPattern.toUpperCase(Locale.ENGLISH) +
+                        " into trim pattern, skipping...");
+
+            ArmorTrim armorTrim = new ArmorTrim(material, pattern);
+            armorMeta.setTrim(armorTrim);
+        }
     }
 
     @Override
@@ -47,6 +79,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
@@ -72,12 +72,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
@@ -72,10 +72,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
@@ -3,16 +3,51 @@ package com.bgsoftware.superiorskyblock.nms.v1_20_4;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+
+import java.util.Locale;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20_4.AbstractNMSAlgorithms {
 
     @Override
     public String parseSignLine(String original) {
         return Component.Serializer.toJson(CraftChatMessage.fromString(original)[0], MinecraftServer.getServer().registryAccess());
+    }
+
+    @Override
+    public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
+        if (itemMeta instanceof ArmorMeta armorMeta) {
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
+
+            if (material == null)
+                throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
+                        " into trim material, skipping...");
+            if (pattern == null)
+                throw new IllegalArgumentException("Couldn't convert " + trimPattern.toUpperCase(Locale.ENGLISH) +
+                        " into trim pattern, skipping...");
+
+            ArmorTrim armorTrim = new ArmorTrim(material, pattern);
+            armorMeta.setTrim(armorTrim);
+        }
     }
 
     @Override
@@ -33,6 +68,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
@@ -78,10 +78,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
@@ -5,6 +5,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -16,7 +18,6 @@ import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21.AbstractNMSAlgorithms {
 
@@ -33,8 +34,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -66,6 +74,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
@@ -78,12 +78,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
@@ -12,6 +12,8 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -24,7 +26,6 @@ import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.lang.reflect.Modifier;
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21_10.AbstractNMSAlgorithms {
 
@@ -54,8 +55,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -82,6 +90,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public double getCurrentTps() {
         return (SERVER_RECENT_TPS.isValid() ? SERVER_RECENT_TPS.get(MinecraftServer.getServer()) : Bukkit.getTPS())[0];
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
@@ -94,12 +94,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
@@ -94,10 +94,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
@@ -83,10 +83,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
@@ -83,12 +83,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
@@ -5,6 +5,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -16,7 +18,6 @@ import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21_3.AbstractNMSAlgorithms {
 
@@ -38,8 +39,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -71,6 +79,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
@@ -5,6 +5,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -16,7 +18,6 @@ import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21_4.AbstractNMSAlgorithms {
 
@@ -38,8 +39,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -71,6 +79,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
@@ -83,10 +83,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
@@ -83,12 +83,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
@@ -5,6 +5,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -16,7 +18,6 @@ import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21_5.AbstractNMSAlgorithms {
 
@@ -38,8 +39,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -71,6 +79,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
@@ -83,10 +83,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
@@ -83,12 +83,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
@@ -6,12 +6,13 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.mojang.serialization.JsonOps;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -23,7 +24,6 @@ import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21_7.AbstractNMSAlgorithms {
 
@@ -50,8 +50,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -83,6 +90,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
             //noinspection removal
             return MinecraftServer.getServer().recentTps[0];
         }
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
@@ -94,12 +94,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
@@ -94,10 +94,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
@@ -12,6 +12,8 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -24,7 +26,6 @@ import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.lang.reflect.Modifier;
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21_9.AbstractNMSAlgorithms {
 
@@ -54,8 +55,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -82,6 +90,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public double getCurrentTps() {
         return (SERVER_RECENT_TPS.isValid() ? SERVER_RECENT_TPS.get(MinecraftServer.getServer()) : Bukkit.getTPS())[0];
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
@@ -94,12 +94,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
@@ -94,10 +94,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_8_R3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_8_R3/NMSAlgorithmsImpl.java
@@ -21,6 +21,7 @@ import net.minecraft.server.v1_8_R3.World;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Biome;
 import org.bukkit.block.BlockState;
 import org.bukkit.command.defaults.BukkitCommand;
 import org.bukkit.craftbukkit.v1_8_R3.CraftServer;
@@ -39,6 +40,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 import java.util.Optional;
 
 public class NMSAlgorithmsImpl implements NMSAlgorithms {
@@ -185,6 +187,14 @@ public class NMSAlgorithmsImpl implements NMSAlgorithms {
         return -1;
     }
 
+    @Override
+    public Biome getBiome(String biomeName) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
     private static Enchantment initializeGlowEnchantment() {
         int enchantId = 100;
         while (Enchantment.getById(enchantId) != null)

--- a/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
+++ b/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
@@ -94,10 +94,7 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1
 
     @Override
     public Biome getBiome(String biomeName) {
-        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
-
-        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
-                NamespacedKey.minecraft(normalized);
+        NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
         if (key == null) {
             return null;
         }

--- a/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
+++ b/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
@@ -94,12 +94,10 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1
 
     @Override
     public Biome getBiome(String biomeName) {
-        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
-        if (!biomeName.contains(":")) {
-            biomeName = "minecraft:" + biomeName;
-        }
+        String normalized = biomeName.toLowerCase(Locale.ENGLISH);
 
-        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        NamespacedKey key = biomeName.contains(":") ? NamespacedKey.fromString(normalized) :
+                NamespacedKey.minecraft(normalized);
         if (key == null) {
             return null;
         }

--- a/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
+++ b/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
@@ -12,6 +12,8 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.block.Biome;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.util.CraftChatMessage;
 import org.bukkit.inventory.ItemRarity;
@@ -24,7 +26,6 @@ import org.bukkit.inventory.meta.trim.TrimPattern;
 
 import java.lang.reflect.Modifier;
 import java.util.Locale;
-import java.util.Objects;
 
 public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1.AbstractNMSAlgorithms {
 
@@ -54,8 +55,15 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1
     @Override
     public void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) {
         if (itemMeta instanceof ArmorMeta armorMeta) {
-            TrimMaterial material = Objects.requireNonNull(Bukkit.getRegistry(TrimMaterial.class)).get(NamespacedKey.minecraft(trimMaterial));
-            TrimPattern pattern = Objects.requireNonNull(Bukkit.getRegistry(TrimPattern.class)).get(NamespacedKey.minecraft(trimPattern));
+            Registry<TrimMaterial> materialRegistry = Bukkit.getRegistry(TrimMaterial.class);
+            Registry<TrimPattern> patternRegistry = Bukkit.getRegistry(TrimPattern.class);
+
+            if (materialRegistry == null || patternRegistry == null) {
+                return;
+            }
+
+            TrimMaterial material = materialRegistry.get(NamespacedKey.minecraft(trimMaterial));
+            TrimPattern pattern = patternRegistry.get(NamespacedKey.minecraft(trimPattern));
 
             if (material == null)
                 throw new IllegalArgumentException("Couldn't convert " + trimMaterial.toUpperCase(Locale.ENGLISH) +
@@ -82,6 +90,26 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1
     @Override
     public double getCurrentTps() {
         return (SERVER_RECENT_TPS.isValid() ? SERVER_RECENT_TPS.get(MinecraftServer.getServer()) : Bukkit.getTPS())[0];
+    }
+
+    @Override
+    public Biome getBiome(String biomeName) {
+        biomeName = biomeName.toLowerCase(Locale.ENGLISH);
+        if (!biomeName.contains(":")) {
+            biomeName = "minecraft:" + biomeName;
+        }
+
+        NamespacedKey key = NamespacedKey.fromString(biomeName);
+        if (key == null) {
+            return null;
+        }
+
+        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+        if (registry == null) {
+            return null;
+        }
+
+        return registry.get(key);
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminSetBiome.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminSetBiome.java
@@ -64,7 +64,7 @@ public class CmdAdminSetBiome implements IAdminIslandCommand {
 
     @Override
     public void execute(SuperiorSkyblockPlugin plugin, CommandSender sender, @Nullable SuperiorPlayer targetPlayer, List<Island> islands, String[] args) {
-        Biome biome = CommandArguments.getBiome(sender, args[3]);
+        Biome biome = CommandArguments.getBiome(plugin, sender, args[3]);
 
         if (biome == null)
             return;

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/arguments/CommandArguments.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/arguments/CommandArguments.java
@@ -315,12 +315,10 @@ public class CommandArguments {
         return islandWarp;
     }
 
-    public static Biome getBiome(CommandSender sender, String argument) {
-        Biome biome = null;
+    public static Biome getBiome(SuperiorSkyblockPlugin plugin, CommandSender sender, String argument) {
+        Biome biome = plugin.getNMSAlgorithms().getBiome(argument);
 
-        try {
-            biome = Biome.valueOf(argument.toUpperCase(Locale.ENGLISH));
-        } catch (Exception ex) {
+        if (biome == null) {
             Message.INVALID_BIOME.send(sender, argument);
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/WorldsSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/WorldsSection.java
@@ -16,7 +16,6 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.Locale;
 import java.util.Map;
 
 public class WorldsSection extends SettingsContainerHolder implements SettingsManager.Worlds {
@@ -85,7 +84,7 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
             this.isEnabled = section.getBoolean("enabled");
             this.isUnlocked = section.getBoolean("unlock");
             this.isSchematicOffset = section.getBoolean("schematic-offset");
-            this.biome = section.getString("biome").toUpperCase(Locale.ENGLISH);
+            this.biome = section.getString("biome");
             String name = section.getString("name");
             this.name = Text.isBlank(name) ? defaultName : name;
             this.portalAgents = loadPortalAgents(section.getConfigurationSection("portals"), dimension);

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/MenuConfig.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/MenuConfig.java
@@ -6,7 +6,6 @@ import com.bgsoftware.superiorskyblock.api.menu.MenuIslandCreationConfig;
 import com.bgsoftware.superiorskyblock.api.schematic.Schematic;
 import com.bgsoftware.superiorskyblock.api.world.GameSound;
 import com.bgsoftware.superiorskyblock.api.wrappers.BlockOffset;
-import com.bgsoftware.superiorskyblock.core.EnumHelper;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.IslandCreationButton;
 import org.bukkit.block.Biome;
 
@@ -37,7 +36,7 @@ public class MenuConfig {
             this.schematic = schematic;
             this.template = template;
             Biome biome = template == null ? null : template.getBiome();
-            this.biome = biome == null ? EnumHelper.getEnum(Biome.class, plugin.getSettings().getWorlds().getDimensionConfig(
+            this.biome = biome == null ? plugin.getNMSAlgorithms().getBiome(plugin.getSettings().getWorlds().getDimensionConfig(
                     plugin.getSettings().getWorlds().getDefaultWorldDimension()).getBiome()) : biome;
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuBiomes.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuBiomes.java
@@ -66,11 +66,9 @@ public class MenuBiomes extends AbstractMenu<IslandMenuView, IslandViewArgs> {
                     continue;
 
                 String biomeName = itemSection.getString("biome");
-                Biome biome;
+                Biome biome = plugin.getNMSAlgorithms().getBiome(biomeName);;
 
-                try {
-                    biome = Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
-                } catch (IllegalArgumentException error) {
+                if (biome == null) {
                     Log.warnFromFile("biomes.yml", "Biome '", biomeName, "' is not valid, skipping...");
                     continue;
                 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandCreation.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuIslandCreation.java
@@ -71,15 +71,16 @@ public class MenuIslandCreation extends AbstractMenu<MenuIslandCreation.View, Me
 
                 {
                     String biomeName = itemSection.getString("biome");
-                    if(biomeName != null) {
-                        try {
-                            Biome biome = Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
-                            buttonBuilder.setBiome(biome);
-                        } catch (IllegalArgumentException error) {
+                    if (biomeName != null) {
+                        Biome biome = plugin.getNMSAlgorithms().getBiome(biomeName);
+
+                        if (biome == null) {
                             Log.warnFromFile("island-creation.yml", "Invalid biome name for item ",
                                     itemSectionName, ": ", biomeName);
                             continue;
                         }
+
+                        buttonBuilder.setBiome(biome);
                     }
                 }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/IslandUtils.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/IslandUtils.java
@@ -69,7 +69,7 @@ public class IslandUtils {
     static {
         for (Dimension dimension : Dimension.values()) {
             Biome biome = Optional.ofNullable(plugin.getSettings().getWorlds().getDimensionConfig(dimension))
-                    .map(config -> EnumHelper.getEnum(Biome.class, config.getBiome()))
+                    .map(config -> plugin.getNMSAlgorithms().getBiome(config.getBiome()))
                     .orElseGet(() -> getDefaultBiomeForEnvironment(dimension.getEnvironment()));
             DEFAULT_WORLD_BIOMES.put(dimension, biome);
         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/nms/NMSAlgorithms.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/nms/NMSAlgorithms.java
@@ -82,6 +82,8 @@ public interface NMSAlgorithms {
 
     int getDataVersion();
 
+    Biome getBiome(String biomeName);
+
     default ClassProcessor getClassProcessor() {
         return null;
     }


### PR DESCRIPTION
I've added the ability to set a custom biomes created using datapacks for islands and island worlds. This change required adding support for NamespacedKey, so instead of using Biome.valueOf(), I've created a new method in the NMS Adapter that allows you to retrieve a biome with a specified namespace in new versions.


So now you can specify the biome in one of these three ways, it is not case sensitive, it will be adjusted depending on the version:
- Without namespace:
  `biome: PLAINS`
- With minecraft namespace (1.19+):
  `biome: minecraft:plains`
- With custom namespace (1.19+):
  `biome: my_datapack:my_biome`
  
When you merge, close this discussion: https://github.com/BG-Software-LLC/SuperiorSkyblock2/discussions/2908 😊

I've also improved the readability of the setTrim method, adding it for NMS 1_20_3 and 1_20_4 (I don't know why I skipped those versions before) and removing it from NMS 1_19, as it was experimental there and couldn't be used without a datapack. Currently, it just displays a bunch of warnings in that file.