### PR TITLE
Added "hideTooltip" option for items

### DIFF
--- a/NMS/src/main/templates/AbstractNMSAlgorithms.java.template
+++ b/NMS/src/main/templates/AbstractNMSAlgorithms.java.template
@@ -220,6 +220,11 @@ public abstract class AbstractNMSAlgorithms implements NMSAlgorithms {
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        // Doesn't exist
+    }
+
+    @Override
     public void addPotion(PotionMeta potionMeta, PotionEffect potionEffect) {
         if (!potionMeta.hasCustomEffects())
             potionMeta.setColor(potionEffect.getType().getColor());

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_12_R1/NMSAlgorithmsImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_12_R1/NMSAlgorithmsImpl.java
@@ -151,6 +151,11 @@ public class NMSAlgorithmsImpl implements NMSAlgorithms {
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        // Doesn't exist
+    }
+
+    @Override
     public void addPotion(PotionMeta potionMeta, PotionEffect potionEffect) {
         if (!potionMeta.hasCustomEffects())
             potionMeta.setColor(potionEffect.getType().getColor());

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_16_R3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_16_R3/NMSAlgorithmsImpl.java
@@ -207,6 +207,11 @@ public class NMSAlgorithmsImpl implements NMSAlgorithms {
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        // Doesn't exist
+    }
+
+    @Override
     public void addPotion(PotionMeta potionMeta, PotionEffect potionEffect) {
         if (!potionMeta.hasCustomEffects())
             potionMeta.setColor(potionEffect.getType().getColor());

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
@@ -51,6 +51,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
@@ -57,6 +57,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
@@ -78,6 +78,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
@@ -62,6 +62,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
@@ -62,6 +62,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
@@ -62,6 +62,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
@@ -73,6 +73,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
@@ -78,6 +78,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_8_R3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_8_R3/NMSAlgorithmsImpl.java
@@ -151,6 +151,11 @@ public class NMSAlgorithmsImpl implements NMSAlgorithms {
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        // Doesn't exist
+    }
+
+    @Override
     public void addPotion(PotionMeta potionMeta, PotionEffect potionEffect) {
         potionMeta.addCustomEffect(potionEffect, true);
     }

--- a/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
+++ b/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
@@ -78,6 +78,11 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1
     }
 
     @Override
+    public void setHideTooltip(ItemMeta itemMeta) {
+        itemMeta.setHideTooltip(true);
+    }
+
+    @Override
     public String getMinecraftKey(ItemStack itemStack) {
         return BuiltInRegistries.ITEM.getKey(CraftItemStack.asNMSCopy(itemStack).getItem()).toString();
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/io/MenuParserImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/io/MenuParserImpl.java
@@ -366,6 +366,10 @@ public class MenuParserImpl implements MenuParser {
             itemBuilder.setUnbreakable();
         }
 
+        if (section.getBoolean("hideTooltip", false)) {
+            itemBuilder.setHideTooltip();
+        }
+
         if (section.isConfigurationSection("effects")) {
             ConfigurationSection effectsSection = section.getConfigurationSection("effects");
             for (String effectName : effectsSection.getKeys(false)) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/itemstack/ItemBuilder.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/itemstack/ItemBuilder.java
@@ -221,6 +221,12 @@ public class ItemBuilder {
         return this;
     }
 
+    public ItemBuilder setHideTooltip() {
+        if (itemMeta != null)
+            plugin.getNMSAlgorithms().setHideTooltip(itemMeta);
+        return this;
+    }
+
     public ItemBuilder withPotionEffect(PotionEffect potionEffect) {
         if (itemMeta instanceof PotionMeta)
             plugin.getNMSAlgorithms().addPotion((PotionMeta) itemMeta, potionEffect);

--- a/src/main/java/com/bgsoftware/superiorskyblock/nms/NMSAlgorithms.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/nms/NMSAlgorithms.java
@@ -67,6 +67,8 @@ public interface NMSAlgorithms {
 
     void setTrim(ItemMeta itemMeta, String trimMaterial, String trimPattern) throws IllegalArgumentException;
 
+    void setHideTooltip(ItemMeta itemMeta);
+
     void addPotion(PotionMeta potionMeta, PotionEffect potionEffect);
 
     String getMinecraftKey(ItemStack itemStack);


### PR DESCRIPTION
With this option, items that don't have any description anyway will instead look like this:
<img width="342" height="109" alt="image" src="https://github.com/user-attachments/assets/8aee753f-e5c2-4593-bb8c-e02284a288ad" />

Can look like this:
<img width="339" height="114" alt="image" src="https://github.com/user-attachments/assets/84117fba-0f42-4dfa-87ab-9b894b41ac50" />


Once you merge this, you can also add information about this option to the wiki 😉
