### PR TITLE
Added missing "Minecart Place" permission to permissions menu for 1.8 and 1.12

### DIFF
--- a/src/main/resources/menus/permissions.yml
+++ b/src/main/resources/menus/permissions.yml
@@ -1363,6 +1363,39 @@ permissions:
         volume: 0.2
         pitch: 0.2
 
+  minecart_place:
+    display-menu: true
+    permission-enabled:
+      type: MINECART
+      name: '&6Minecart Place'
+      lore:
+        - '&7Access to place minecarts inside the island.'
+        - '&7Currently &aENABLED&7.'
+    permission-disabled:
+      type: MINECART
+      name: '&6Minecart Place'
+      lore:
+        - '&7Access to place minecarts inside the island.'
+        - '&7Currently &cDISABLED&7.'
+    role-permission:
+      type: MINECART
+      name: '&6Minecart Place'
+      lore:
+        - '&7Access to place minecarts inside the island.'
+        - '&7Role: &e{}&7.'
+        - ''
+        - '{0}'
+    has-access:
+      sound:
+        type: ORB_PICKUP
+        volume: 0.2
+        pitch: 0.2
+    no-access:
+      sound:
+        type: ANVIL_LAND
+        volume: 0.2
+        pitch: 0.2
+
   monster_damage:
     display-menu: true
     permission-enabled:

--- a/src/main/resources/menus/permissions1_12.yml
+++ b/src/main/resources/menus/permissions1_12.yml
@@ -1396,6 +1396,39 @@ permissions:
         volume: 0.2
         pitch: 0.2
 
+  minecart_place:
+    display-menu: true
+    permission-enabled:
+      type: MINECART
+      name: '&6Minecart Place'
+      lore:
+        - '&7Access to place minecarts inside the island.'
+        - '&7Currently &aENABLED&7.'
+    permission-disabled:
+      type: MINECART
+      name: '&6Minecart Place'
+      lore:
+        - '&7Access to place minecarts inside the island.'
+        - '&7Currently &cDISABLED&7.'
+    role-permission:
+      type: MINECART
+      name: '&6Minecart Place'
+      lore:
+        - '&7Access to place minecarts inside the island.'
+        - '&7Role: &e{}&7.'
+        - ''
+        - '{0}'
+    has-access:
+      sound:
+        type: ENTITY_EXPERIENCE_ORB_PICKUP
+        volume: 0.2
+        pitch: 0.2
+    no-access:
+      sound:
+        type: BLOCK_ANVIL_PLACE
+        volume: 0.2
+        pitch: 0.2
+
   monster_damage:
     display-menu: true
     permission-enabled:


### PR DESCRIPTION
Hah, however, my introduction of warnings about missing permissions/settings was useful, because besides informing about unnecessary permissions that shouldn't be registered (which you already fixed), it also informed about the missing Minecart Place privilege, and right, it was missing for 1.8 and 1.12. I wonder how long this was missing 😂