### PR TITLE
Fix getBiome registry lookup silently returning null on Paper 1.20.4

### DIFF
--- a/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
+++ b/NMS/v1_19/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_19/NMSAlgorithmsImpl.java
@@ -50,16 +50,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_19
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_3/NMSAlgorithmsImpl.java
@@ -84,16 +84,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_20_4/NMSAlgorithmsImpl.java
@@ -78,16 +78,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_20
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21/NMSAlgorithmsImpl.java
@@ -84,16 +84,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_10/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_10/NMSAlgorithmsImpl.java
@@ -100,16 +100,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_3/NMSAlgorithmsImpl.java
@@ -89,16 +89,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_4/NMSAlgorithmsImpl.java
@@ -89,16 +89,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_5/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_5/NMSAlgorithmsImpl.java
@@ -89,16 +89,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_7/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_7/NMSAlgorithmsImpl.java
@@ -100,16 +100,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
+++ b/NMS/v1_21_9/src/main/java/com/bgsoftware/superiorskyblock/nms/v1_21_9/NMSAlgorithmsImpl.java
@@ -100,16 +100,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v1_21
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }

--- a/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
+++ b/NMS/v26_1/src/main/java/com/bgsoftware/superiorskyblock/nms/v26_1/NMSAlgorithmsImpl.java
@@ -100,16 +100,21 @@ public class NMSAlgorithmsImpl extends com.bgsoftware.superiorskyblock.nms.v26_1
     @Override
     public Biome getBiome(String biomeName) {
         NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ENGLISH));
-        if (key == null) {
-            return null;
+        if (key != null) {
+            Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
+            if (registry != null) {
+                Biome biome = registry.get(key);
+                if (biome != null) {
+                    return biome;
+                }
+            }
         }
 
-        Registry<Biome> registry = Bukkit.getRegistry(Biome.class);
-        if (registry == null) {
+        try {
+            return Biome.valueOf(biomeName.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
             return null;
         }
-
-        return registry.get(key);
     }
 
 }


### PR DESCRIPTION
On Paper 1.20.4, Bukkit.getRegistry(Biome.class) can return null or
produce an empty result during plugin initialization, causing all biome
names (including valid ones like PLAINS) to be rejected with the
"is not valid, skipping..." warning.

Add Biome.valueOf() as a fallback in all post-1.18 NMS modules so that
standard enum biome names resolve correctly when the registry lookup
fails. The registry path is still tried first so namespaced keys and
datapack biomes continue to work as before.

https://claude.ai/code/session_01YauxJaZ7V6AEwNZjTjx5Kq