### PR TITLE
Fix /is bal showing command sender name on visited islands

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/arguments/CommandArguments.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/arguments/CommandArguments.java
@@ -131,7 +131,9 @@ public class CommandArguments {
         if (island == null)
             Message.INVALID_ISLAND.send(sender);
 
-        return new IslandArgument(island, superiorPlayer);
+        SuperiorPlayer targetPlayer = island.equals(superiorPlayer.getIsland()) ? superiorPlayer : island.getOwner();
+
+        return new IslandArgument(island, targetPlayer);
     }
 
     public static Mission<?> getMission(SuperiorSkyblockPlugin plugin, SuperiorPlayer superiorPlayer, String argument) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdBalance.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/module/bank/commands/CmdBalance.java
@@ -66,12 +66,13 @@ public class CmdBalance implements ISuperiorCommand {
         SuperiorPlayer superiorPlayer = plugin.getPlayers().getSuperiorPlayer(sender);
         SuperiorPlayer targetPlayer = arguments.getSuperiorPlayer();
 
-        if (island == superiorPlayer.getIsland())
+        if (island.equals(superiorPlayer.getIsland())) {
             Message.ISLAND_BANK_SHOW.send(sender, island.getIslandBank().getBalance());
-        else if (targetPlayer == null)
+        } else if (targetPlayer == null || !targetPlayer.getUniqueId().equals(island.getOwner().getUniqueId())) {
             Message.ISLAND_BANK_SHOW_OTHER_NAME.send(sender, island.getName(), island.getIslandBank().getBalance());
-        else
+        } else {
             Message.ISLAND_BANK_SHOW_OTHER.send(sender, targetPlayer.getName(), island.getIslandBank().getBalance());
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Fix `getIslandWhereStanding` to return the island owner as the target player when the command sender is standing on another island.
- Harden `/is bal` message selection so the balance output uses the island owner or island name instead of the visitor when the resolved target player does not match the island owner.

## Problem
When a player teleported to another island and ran `/is bal` without arguments, the balance amount was correct but the message still showed the visitor's name instead of the visited island owner.

## Test plan
- [ ] Run `/is bal` on your own island and confirm the "your island" message is shown with the correct balance.
- [ ] Teleport to another player's island warp and run `/is bal`; confirm the message shows the visited island owner/name with that island's balance.
- [ ] Run `/is bal <player>` and `/is bal <island-name>` and confirm existing targeted balance output still works.
