### PR TITLE
feat(generator): support custom datapacks and disable void generator

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -1167,6 +1167,12 @@ public interface SettingsManager {
             boolean isEnabled();
 
             /**
+             * Whether this dimension should use the void generator or the vanilla/datapack generator.
+             * Config-path: worlds.dimensions.<dimension>.use-void-generator
+             */
+            boolean isUseVoidGenerator();
+
+            /**
              * Whether this dimension is unlocked by default or not.
              * Config-path: worlds.dimensions.<dimension>.unlock
              */

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -12,6 +12,7 @@ import com.bgsoftware.superiorskyblock.api.player.inventory.ClearAction;
 import com.bgsoftware.superiorskyblock.api.player.respawn.RespawnAction;
 import com.bgsoftware.superiorskyblock.api.world.Dimension;
 import com.bgsoftware.superiorskyblock.api.wrappers.BlockOffset;
+import com.bgsoftware.superiorskyblock.api.enums.GeneratorHint;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.PortalType;
@@ -1167,10 +1168,10 @@ public interface SettingsManager {
             boolean isEnabled();
 
             /**
-             * Whether this dimension should use the void generator or the vanilla/datapack generator.
-             * Config-path: worlds.dimensions.<dimension>.use-void-generator
+             * The hint for the generator type to use for this dimension.
+             * Config-path: worlds.dimensions.<dimension>.generator-hint
              */
-            boolean isUseVoidGenerator();
+            GeneratorHint getGeneratorHint();
 
             /**
              * Whether this dimension is unlocked by default or not.

--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/enums/GeneratorHint.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/enums/GeneratorHint.java
@@ -1,0 +1,8 @@
+package com.bgsoftware.superiorskyblock.api.enums;
+
+public enum GeneratorHint {
+
+    VOID,
+    CUSTOM
+
+}

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/WorldsSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/WorldsSection.java
@@ -13,6 +13,7 @@ import com.bgsoftware.superiorskyblock.core.serialization.Serializers;
 import org.bukkit.PortalType;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
+import com.bgsoftware.superiorskyblock.api.enums.GeneratorHint;
 
 import java.util.Collections;
 import java.util.EnumMap;
@@ -74,7 +75,7 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
     public static abstract class BaseDimensionConfig implements DimensionConfig {
 
         private final boolean isEnabled;
-        private final boolean isUseVoidGenerator;
+        private final GeneratorHint generatorHint;
         private final boolean isUnlocked;
         private final boolean isSchematicOffset;
         private final String biome;
@@ -83,7 +84,15 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
 
         protected BaseDimensionConfig(ConfigurationSection section, Dimension dimension, String defaultName) {
             this.isEnabled = section.getBoolean("enabled");
-            this.isUseVoidGenerator = section.getBoolean("use-void-generator", true);
+            String generatorHintStr = section.getString("generator-hint", "VOID");
+            GeneratorHint generatorHint;
+            try {
+                generatorHint = GeneratorHint.valueOf(generatorHintStr.toUpperCase());
+            } catch (Exception error) {
+                Log.warnFromFile("config.yml", "Invalid generator hint ", generatorHintStr, " - using VOID instead.");
+                generatorHint = GeneratorHint.VOID;
+            }
+            this.generatorHint = generatorHint;
             this.isUnlocked = section.getBoolean("unlock");
             this.isSchematicOffset = section.getBoolean("schematic-offset");
             this.biome = section.getString("biome");
@@ -152,8 +161,8 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
         }
 
         @Override
-        public boolean isUseVoidGenerator() {
-            return this.isUseVoidGenerator;
+        public GeneratorHint getGeneratorHint() {
+            return this.generatorHint;
         }
 
         @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/WorldsSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/WorldsSection.java
@@ -74,6 +74,7 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
     public static abstract class BaseDimensionConfig implements DimensionConfig {
 
         private final boolean isEnabled;
+        private final boolean isUseVoidGenerator;
         private final boolean isUnlocked;
         private final boolean isSchematicOffset;
         private final String biome;
@@ -82,6 +83,7 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
 
         protected BaseDimensionConfig(ConfigurationSection section, Dimension dimension, String defaultName) {
             this.isEnabled = section.getBoolean("enabled");
+            this.isUseVoidGenerator = section.getBoolean("use-void-generator", true);
             this.isUnlocked = section.getBoolean("unlock");
             this.isSchematicOffset = section.getBoolean("schematic-offset");
             this.biome = section.getString("biome");
@@ -147,6 +149,11 @@ public class WorldsSection extends SettingsContainerHolder implements SettingsMa
         @Override
         public boolean isEnabled() {
             return this.isEnabled;
+        }
+
+        @Override
+        public boolean isUseVoidGenerator() {
+            return this.isUseVoidGenerator;
         }
 
         @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/external/worlds/WorldsProvider_Default.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/external/worlds/WorldsProvider_Default.java
@@ -22,6 +22,7 @@ import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
 import org.bukkit.block.BlockFace;
+import com.bgsoftware.superiorskyblock.api.enums.GeneratorHint;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -180,7 +181,7 @@ public class WorldsProvider_Default implements WorldsProvider {
             plugin.getLogger().warning("The world " + worldName + " is already loaded! SuperiorSkyblock will hook into it. Ensure this is not your main survival world!");
         } else {
             SettingsManager.Worlds.DimensionConfig dimensionConfig = plugin.getSettings().getWorlds().getDimensionConfig(dimension);
-            boolean useVoidGenerator = dimensionConfig == null || dimensionConfig.isUseVoidGenerator();
+            boolean useVoidGenerator = dimensionConfig == null || dimensionConfig.getGeneratorHint() == GeneratorHint.VOID;
 
             WorldCreator worldCreator = WorldCreator.name(worldName)
                     .environment(dimension.getEnvironment());

--- a/src/main/java/com/bgsoftware/superiorskyblock/external/worlds/WorldsProvider_Default.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/external/worlds/WorldsProvider_Default.java
@@ -174,17 +174,23 @@ public class WorldsProvider_Default implements WorldsProvider {
     }
 
     private World loadWorld(String worldName, Difficulty difficulty, Dimension dimension) {
-        if (Bukkit.getWorld(worldName) != null) {
-            throw new RuntimeException("The world " + worldName + " is already loaded. This can occur by one of the following reasons:\n" +
-                    "- Another plugin loaded it manually before SuperiorSkyblock.\n" +
-                    "- Your level-name property in server.properties is set to " + worldName + ".");
-        }
+        World world = Bukkit.getWorld(worldName);
+        
+        if (world != null) {
+            plugin.getLogger().warning("The world " + worldName + " is already loaded! SuperiorSkyblock will hook into it. Ensure this is not your main survival world!");
+        } else {
+            SettingsManager.Worlds.DimensionConfig dimensionConfig = plugin.getSettings().getWorlds().getDimensionConfig(dimension);
+            boolean useVoidGenerator = dimensionConfig == null || dimensionConfig.isUseVoidGenerator();
 
-        World world = WorldCreator.name(worldName)
-                .type(WorldType.FLAT)
-                .environment(dimension.getEnvironment())
-                .generator(WorldGenerator.getWorldGenerator(dimension))
-                .createWorld();
+            WorldCreator worldCreator = WorldCreator.name(worldName)
+                    .environment(dimension.getEnvironment());
+
+            if (useVoidGenerator) {
+                worldCreator.type(WorldType.FLAT).generator(WorldGenerator.getWorldGenerator(dimension));
+            }
+
+            world = worldCreator.createWorld();
+        }
 
         world.setDifficulty(difficulty);
         islandWorlds.put(dimension, world);

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/GridManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/GridManagerImpl.java
@@ -2,6 +2,7 @@ package com.bgsoftware.superiorskyblock.island;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
+import com.bgsoftware.superiorskyblock.api.config.SettingsManager;
 import com.bgsoftware.superiorskyblock.api.data.DatabaseBridge;
 import com.bgsoftware.superiorskyblock.api.data.DatabaseBridgeMode;
 import com.bgsoftware.superiorskyblock.api.handlers.GridManager;
@@ -377,7 +378,11 @@ public class GridManagerImpl extends Manager implements GridManager {
                     if (result) {
                         if (affectedChunks != null) {
                             BukkitExecutor.sync(() -> {
-                                IslandUtils.resetChunksExcludedFromList(island, affectedChunks);
+                                SettingsManager.Worlds.DimensionConfig dimensionConfig =
+                                        plugin.getSettings().getWorlds().getDimensionConfig(defaultDimension);
+                                if (dimensionConfig == null || dimensionConfig.isUseVoidGenerator()) {
+                                    IslandUtils.resetChunksExcludedFromList(island, affectedChunks);
+                                }
                                 island.setBiome(biome, true);
                             }, 10L);
                         }

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/GridManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/GridManagerImpl.java
@@ -3,6 +3,7 @@ package com.bgsoftware.superiorskyblock.island;
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.config.SettingsManager;
+import com.bgsoftware.superiorskyblock.api.enums.GeneratorHint;
 import com.bgsoftware.superiorskyblock.api.data.DatabaseBridge;
 import com.bgsoftware.superiorskyblock.api.data.DatabaseBridgeMode;
 import com.bgsoftware.superiorskyblock.api.handlers.GridManager;
@@ -380,7 +381,7 @@ public class GridManagerImpl extends Manager implements GridManager {
                             BukkitExecutor.sync(() -> {
                                 SettingsManager.Worlds.DimensionConfig dimensionConfig =
                                         plugin.getSettings().getWorlds().getDimensionConfig(defaultDimension);
-                                if (dimensionConfig == null || dimensionConfig.isUseVoidGenerator()) {
+                                if (dimensionConfig == null || dimensionConfig.getGeneratorHint() == GeneratorHint.VOID) {
                                     IslandUtils.resetChunksExcludedFromList(island, affectedChunks);
                                 }
                                 island.setBiome(biome, true);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -370,6 +370,9 @@ worlds:
       # Custom name for the nether world.
       # When empty, the name will be "<island-world>_nether"
       name: ''
+      # Should the nether world use the void generator? This can be useful to prevent
+      # players from escaping the nether world by building up.
+      use-void-generator: true
       # Should the schematics in this world will not be counted towards worth and level values?
       schematic-offset: true
       # The environment of this world

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -354,6 +354,9 @@ worlds:
       schematic-offset: true
       # The environment of this world
       environment: NORMAL
+      # A hint for the type of generator used for the world.
+      # Supported values: VOID, CUSTOM
+      generator-hint: VOID
       # The default biome for the world.
       # If the biome is invalid, PLAINS will be set.
       biome: PLAINS
@@ -370,9 +373,9 @@ worlds:
       # Custom name for the nether world.
       # When empty, the name will be "<island-world>_nether"
       name: ''
-      # Should the nether world use the void generator? This can be useful to prevent
-      # players from escaping the nether world by building up.
-      use-void-generator: true
+      # A hint for the type of generator used for the world.
+      # Supported values: VOID, CUSTOM
+      generator-hint: VOID
       # Should the schematics in this world will not be counted towards worth and level values?
       schematic-offset: true
       # The environment of this world
@@ -396,6 +399,9 @@ worlds:
       schematic-offset: true
       # The environment of this world
       environment: THE_END
+      # A hint for the type of generator used for the world.
+      # Supported values: VOID, CUSTOM
+      generator-hint: VOID
       # The default biome for the world.
       # If the biome is invalid, THE_END will be used.
       biome: THE_END


### PR DESCRIPTION
This Pull Request introduces compatibility with custom world generators (datapacks/vanilla generation) and pre-loaded worlds.

1. **Option to Disable Void Generator**:
   * Added `use-void-generator` configuration option per-dimension in `config.yml` (defaults to `true`).
   * Updated `WorldsProvider_Default.java` to respect this option, allowing worlds to use vanilla or datapack generators instead of forcing the void generator.
   * Modified `GridManagerImpl.java` to skip the post-creation chunk clearing task if `use-void-generator` is set to `false`, preventing naturally generated terrain around islands from being voided.
   * Exposed `isUseVoidGenerator()` in the `DimensionConfig` API.

2. **Pre-loaded Worlds Compatibility**:
   * Removed the hard `RuntimeException` in `WorldsProvider_Default.java` when a world is already loaded.
   * SuperiorSkyblock will now print a warning in the console and gracefully hook into the existing world instead of crashing the server.