### PR TITLE
Fixed comments for island-top-order and global-warps-order

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -169,12 +169,14 @@ island-level-rounding-mode: 'HALF_UP'
 # placement and breaking of blocks.
 auto-blocks-tracking: true
 
-# How should the island top be ordered by default?
-# Use WORTH, LEVEL, RATING or PLAYERS.
+# Which sorting type should be used by default for the island top?
+# The default available sorting types: WORTH, LEVEL, RATING, PLAYERS, BANK
+# Custom sorting types can be registered using the API.
 island-top-order: 'WORTH'
 
-# How should the global warps be ordered by default?
-# Use WORTH, LEVEL, RATING or PLAYERS.
+# Which sorting type should be used by default for the global warps?
+# The default available sorting types: WORTH, LEVEL, RATING, PLAYERS, BANK
+# Custom sorting types can be registered using the API.
 global-warps-order: 'WORTH'
 
 # Whether coop members should be enabled or not.


### PR DESCRIPTION
Could you also update the [wiki](https://wiki.bg-software.com/superiorskyblock/overview/placeholders/global-placeholders) so that, instead of listing the same placeholders separately for each sorting type, you list them once and specify the default sorting types there? Please include the new 'bank' sorting type, as well as the 'value_raw' and 'value_format' placeholders variants, since currently only 'value' is listed.