### PR TITLE
Fixed formatting legacy color codes in /is admin title and /is admin titleall

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminTitle.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/admin/CmdAdminTitle.java
@@ -7,6 +7,7 @@ import com.bgsoftware.superiorskyblock.commands.IAdminPlayerCommand;
 import com.bgsoftware.superiorskyblock.commands.arguments.CommandArguments;
 import com.bgsoftware.superiorskyblock.commands.arguments.NumberArgument;
 import com.bgsoftware.superiorskyblock.core.LazyReference;
+import com.bgsoftware.superiorskyblock.core.formatting.Formatters;
 import com.bgsoftware.superiorskyblock.core.messages.Message;
 import org.bukkit.command.CommandSender;
 
@@ -102,7 +103,8 @@ public class CmdAdminTitle implements IAdminPlayerCommand {
         }
 
         MessagesService.Builder builder = messagesService.get().newBuilder();
-        builder.addTitle(title, subtitle, fadeIn.getNumber(), duration.getNumber(), fadeOut.getNumber());
+        builder.addTitle(Formatters.COLOR_FORMATTER.format(title),
+                Formatters.COLOR_FORMATTER.format(subtitle), fadeIn.getNumber(), duration.getNumber(), fadeOut.getNumber());
         builder.build().sendMessage(targetPlayer.asPlayer());
 
         Message.TITLE_SENT.send(sender, targetPlayer.getName());

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/messages/Message.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/messages/Message.java
@@ -20,7 +20,6 @@ import com.bgsoftware.superiorskyblock.core.io.Files;
 import com.bgsoftware.superiorskyblock.core.logging.Debug;
 import com.bgsoftware.superiorskyblock.core.logging.Log;
 import com.bgsoftware.superiorskyblock.player.PlayerLocales;
-import com.bgsoftware.superiorskyblock.service.message.MessagesServiceImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -2240,7 +2240,8 @@ public class SIsland implements Island {
 
         forEachIslandMember(ignoredMembers, true, islandMember -> {
             MessagesService.Builder builder = messagesService.get().newBuilder();
-            builder.addTitle(title, subtitle, fadeIn, duration, fadeOut);
+            builder.addTitle(Formatters.COLOR_FORMATTER.format(title),
+                    Formatters.COLOR_FORMATTER.format(subtitle), fadeIn, duration, fadeOut);
             builder.build().sendMessage(islandMember.asPlayer());
         });
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/service/message/MessagesServiceImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/service/message/MessagesServiceImpl.java
@@ -73,8 +73,7 @@ public class MessagesServiceImpl implements MessagesService, IService {
 
         @Override
         public boolean addBossBar(@Nullable String message, BossBar.Color color, int duration) {
-            return addMessageComponent(plugin.getProviders().getMessagesProvider()
-                    .createBossBarComponent(message, color, BossBar.Style.SOLID, duration));
+            return addBossBar(message, color, BossBar.Style.SOLID, duration);
         }
 
         @Override
@@ -101,7 +100,7 @@ public class MessagesServiceImpl implements MessagesService, IService {
 
         @Override
         public boolean addSound(Sound sound, float volume, float pitch) {
-            return addMessageComponent(SoundComponent.of(new GameSoundImpl(sound, volume, pitch)));
+            return addSound(new GameSoundImpl(sound, volume, pitch));
         }
 
         @Override


### PR DESCRIPTION
I moved the use of the color formatter from the providers to the messages service, but I forgot that it's missing when creating the title manually using command 😅