### PR TITLE
Added support for using a prices provider other than ShopGUIPlus

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/config/SettingsManager.java
@@ -256,20 +256,6 @@ public interface SettingsManager {
     boolean isTransferConfirm();
 
     /**
-     * The spawners-provider to use.
-     * If set to AUTO, the plugin will automatically detect an available spawners provider and use it.
-     * Config-path: spawners-provider
-     */
-    String getSpawnersProvider();
-
-    /**
-     * The stacked-blocks provider to use.
-     * If set to AUTO, the plugin will automatically detect an available stacked-blocks provider and use it.
-     * Config-path: stacked-blocks-provider
-     */
-    String getStackedBlocksProvider();
-
-    /**
      * Whether inventory of island members should be cleared when their island is disbanded or not.
      * Return true if clear-on-disband contains both ENDER_CHEST and INVENTORY.
      * This method will be deleted in the future!
@@ -563,6 +549,27 @@ public interface SettingsManager {
      * Config-path: obsidian-to-lava
      */
     boolean isObsidianToLava();
+
+    /**
+     * The spawners provider to use.
+     * If set to AUTO, the plugin will automatically detect an available spawners provider and use it.
+     * Config-path: spawners-provider
+     */
+    String getSpawnersProvider();
+
+    /**
+     * The stacked-blocks provider to use.
+     * If set to AUTO, the plugin will automatically detect an available stacked-blocks provider and use it.
+     * Config-path: stacked-blocks-provider
+     */
+    String getStackedBlocksProvider();
+
+    /**
+     * The prices provider to use.
+     * If set to AUTO, the plugin will automatically detect an available prices provider and use it.
+     * Config-path: prices-provider
+     */
+    String getPricesProvider();
 
     /**
      * The sync-worth status of the plugin.

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -150,8 +150,6 @@ public class SettingsContainer {
     public final boolean kickConfirm;
     public final boolean leaveConfirm;
     public final boolean transferConfirm;
-    public final String spawnersProvider;
-    public final String stackedBlocksProvider;
     public final boolean islandNamesRequiredForCreation;
     public final int islandNamesMaxLength;
     public final int islandNamesMinLength;
@@ -206,6 +204,9 @@ public class SettingsContainer {
     public final boolean defaultIslandFly;
     public final String defaultBorderColor;
     public final boolean obsidianToLava;
+    public final String spawnersProvider;
+    public final String stackedBlocksProvider;
+    public final String pricesProvider;
     public final BlockValuesManagerImpl.SyncWorthStatus syncWorth;
     public final boolean negativeWorth;
     public final boolean negativeLevel;
@@ -392,8 +393,6 @@ public class SettingsContainer {
         kickConfirm = config.getBoolean("kick-confirm");
         leaveConfirm = config.getBoolean("leave-confirm");
         transferConfirm = config.getBoolean("transfer-confirm");
-        spawnersProvider = config.getString("spawners-provider", "AUTO");
-        stackedBlocksProvider = config.getString("stacked-blocks-provider", "AUTO");
         islandNamesRequiredForCreation = config.getBoolean("island-names.required-for-creation", true);
         islandNamesMaxLength = config.getInt("island-names.max-length", 16);
         islandNamesMinLength = config.getInt("island-names.min-length", 3);
@@ -513,6 +512,9 @@ public class SettingsContainer {
         defaultIslandFly = config.getBoolean("default-island-fly", false);
         defaultBorderColor = config.getString("default-border-color", "BLUE");
         obsidianToLava = config.getBoolean("obsidian-to-lava", false);
+        spawnersProvider = config.getString("spawners-provider", "AUTO");
+        stackedBlocksProvider = config.getString("stacked-blocks-provider", "AUTO");
+        pricesProvider = config.getString("prices-provider", "AUTO");
         syncWorth = BlockValuesManagerImpl.SyncWorthStatus.of(config.getString("sync-worth", "NONE"));
         negativeWorth = config.getBoolean("negative-worth", true);
         negativeLevel = config.getBoolean("negative-level", true);

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -288,16 +288,6 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     }
 
     @Override
-    public String getSpawnersProvider() {
-        return this.global.getSpawnersProvider();
-    }
-
-    @Override
-    public String getStackedBlocksProvider() {
-        return this.global.getStackedBlocksProvider();
-    }
-
-    @Override
     public boolean isDisbandInventoryClear() {
         List<ClearAction> clearActions = this.global.getClearActionsOnDisband();
         return clearActions.contains(ClearActions.ENDER_CHEST) && clearActions.contains(ClearActions.INVENTORY);
@@ -527,6 +517,21 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     @Override
     public boolean isObsidianToLava() {
         return this.global.isObsidianToLava();
+    }
+
+    @Override
+    public String getSpawnersProvider() {
+        return this.global.getSpawnersProvider();
+    }
+
+    @Override
+    public String getStackedBlocksProvider() {
+        return this.global.getStackedBlocksProvider();
+    }
+
+    @Override
+    public String getPricesProvider() {
+        return this.global.getPricesProvider();
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/GlobalSection.java
@@ -5,7 +5,6 @@ import com.bgsoftware.superiorskyblock.api.enums.TopIslandMembersSorting;
 import com.bgsoftware.superiorskyblock.api.handlers.BlockValuesManager;
 import com.bgsoftware.superiorskyblock.api.island.SortingType;
 import com.bgsoftware.superiorskyblock.api.key.Key;
-import com.bgsoftware.superiorskyblock.api.key.KeySet;
 import com.bgsoftware.superiorskyblock.api.objects.Pair;
 import com.bgsoftware.superiorskyblock.api.player.inventory.ClearAction;
 import com.bgsoftware.superiorskyblock.api.player.respawn.RespawnAction;
@@ -134,14 +133,6 @@ public class GlobalSection extends SettingsContainerHolder {
 
     public boolean isTransferConfirm() {
         return getContainer().transferConfirm;
-    }
-
-    public String getSpawnersProvider() {
-        return getContainer().spawnersProvider;
-    }
-
-    public String getStackedBlocksProvider() {
-        return getContainer().stackedBlocksProvider;
     }
 
     public boolean isTeleportOnCreate() {
@@ -306,6 +297,18 @@ public class GlobalSection extends SettingsContainerHolder {
 
     public boolean isObsidianToLava() {
         return getContainer().obsidianToLava;
+    }
+
+    public String getSpawnersProvider() {
+        return getContainer().spawnersProvider;
+    }
+
+    public String getStackedBlocksProvider() {
+        return getContainer().stackedBlocksProvider;
+    }
+
+    public String getPricesProvider() {
+        return getContainer().pricesProvider;
     }
 
     public BlockValuesManager.SyncWorthStatus getSyncWorth() {

--- a/src/main/java/com/bgsoftware/superiorskyblock/external/ProvidersManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/external/ProvidersManagerImpl.java
@@ -663,8 +663,13 @@ public class ProvidersManagerImpl extends Manager implements ProvidersManager {
     }
 
     private void registerPricesProvider() {
-        ShopsProvider.SHOPGUIPLUS.createInstance(plugin)
-                .map(shopsBridge -> new PricesProvider_ShopsBridgeWrapper(plugin, ShopsProvider.SHOPGUIPLUS, shopsBridge))
+        String pricesProviderName = plugin.getSettings().getPricesProvider();
+
+        Optional<ShopsProvider> shopsProvider = (pricesProviderName.equalsIgnoreCase("AUTO") ?
+                ShopsProvider.findAvailableProvider() : ShopsProvider.getShopsProvider(pricesProviderName));
+
+        shopsProvider.flatMap(provider -> provider.createInstance(plugin)
+                .map(shopsBridge -> new PricesProvider_ShopsBridgeWrapper(plugin, provider, shopsBridge)))
                 .ifPresent(this::setPricesProvider);
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -486,14 +486,6 @@ leave-confirm: true
 # Should a confirm gui be displayed when /is transfer is executed.
 transfer-confirm: true
 
-# If you want a specific spawners provider to use, specify it here.
-# Providers: Auto, WildStacker, EpicSpawners, MergedSpawner, PvpingSpawners, SilkSpawners, RoseStacker
-spawners-provider: 'AUTO'
-
-# If you want a specific stacked-blocks provider to use, specify it here.
-# Providers: Auto, WildStacker, RoseStacker
-stacked-blocks-provider: 'AUTO'
-
 # All settings related to island names.
 island-names:
   # Should creation of islands will ask for name (/is create <name>)?
@@ -802,10 +794,21 @@ default-border-color: BLUE
 # Should obsidian get turned into a lava bucket when clicking it with a bucket in hand?
 obsidian-to-lava: false
 
-# Should the worth values be synced with other prices providers?
+# If you want a specific spawners provider to use, specify it here.
+# Providers: Auto, AdvancedSpawners, EpicSpawners, MergedSpawner, PvpingSpawners, RoseStacker, SilkSpawners, UltimateStacker, WildStacker
+spawners-provider: 'AUTO'
+
+# If you want a specific stacked-blocks provider to use, specify it here.
+# Providers: Auto, RoseStacker, WildStacker
+stacked-blocks-provider: 'AUTO'
+
+# If you want a specific prices provider to use, specify it here.
+# Providers: Auto, CMI, EconomyShopGUI, Essentials, ExcellentShop, GUIShop, newtShop, NextGens, QuantumShop, ShopGUIPlus, zShop
+prices-provider: 'AUTO'
+
+# Should the worth values be synced with the prices provider?
 # You can set the following values: NONE (disabled), BUY (buy prices), SELL (sell prices)
-# Supported Providers: ShopGUIPlus
-sync-worth: NONE
+sync-worth: 'NONE'
 
 # Can the worth value of the island be negative?
 negative-worth: true


### PR DESCRIPTION
- Added support for using any prices provider for the sync worth feature, rather than just ShopGUIPlus as before (similar to WildChest or WildTools).
- Moved the spawners-provider and stacked-blocks-provider options in the configuration so they are next to prices-provider and sync-worth. While doing so, I updated their comments, added all current providers, and arranged them alphabetically.

Once merged, you can close https://github.com/BG-Software-LLC/SuperiorSkyblock2/discussions/1556