### PR TITLE
Fixed errors when accessing blocks of unloaded worlds

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/LazyWorldLocation.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/LazyWorldLocation.java
@@ -13,9 +13,16 @@ import org.bukkit.World;
  */
 public class LazyWorldLocation extends Location {
 
+    /**
+     * Incremented every time a world is unloaded. Cached world references that were resolved
+     * with an older generation must be resolved again, as they may point to an unloaded world.
+     */
+    private static int worldsGeneration = 0;
+
     @Nullable
     private String worldName;
     private boolean updatedWorld = false;
+    private int cachedWorldsGeneration = 0;
 
     public static LazyWorldLocation of(Location location) {
         if (location instanceof LazyWorldLocation)
@@ -58,7 +65,7 @@ public class LazyWorldLocation extends Location {
 
     @Override
     public World getWorld() {
-        if (!this.updatedWorld) {
+        if (!this.updatedWorld || this.cachedWorldsGeneration != worldsGeneration) {
             updateWorldInternal(worldName == null ? null : Bukkit.getWorld(worldName));
         }
 
@@ -74,6 +81,7 @@ public class LazyWorldLocation extends Location {
     private void updateWorldInternal(@Nullable World world) {
         super.setWorld(world);
         this.updatedWorld = true;
+        this.cachedWorldsGeneration = worldsGeneration;
     }
 
     @Override
@@ -84,6 +92,23 @@ public class LazyWorldLocation extends Location {
     public Location clone(boolean keepLazy) {
         return keepLazy || getWorld() == null ? new LazyWorldLocation(this.worldName, getX(), getY(), getZ(), getYaw(), getPitch()) :
                 super.clone();
+    }
+
+    /**
+     * Invalidates all cached world references of lazy locations.
+     * Must be called whenever a world is unloaded, as accessing blocks or chunks of an unloaded
+     * world throws an exception - its chunk-system is shut down.
+     */
+    public static void notifyWorldUnloaded() {
+        ++worldsGeneration;
+    }
+
+    /**
+     * Checks whether the given world is currently loaded on the server.
+     * A reference of an unloaded world may still be held by objects, but must never be accessed.
+     */
+    public static boolean isWorldLoaded(@Nullable World world) {
+        return world != null && Bukkit.getWorld(world.getName()) == world;
     }
 
     public static String getWorldName(Location location) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/LazyWorldLocation.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/LazyWorldLocation.java
@@ -17,12 +17,12 @@ public class LazyWorldLocation extends Location {
      * Incremented every time a world is unloaded. Cached world references that were resolved
      * with an older generation must be resolved again, as they may point to an unloaded world.
      */
-    private static int worldsGeneration = 0;
+    private static long worldsGeneration = Long.MIN_VALUE;
 
     @Nullable
     private String worldName;
     private boolean updatedWorld = false;
-    private int cachedWorldsGeneration = 0;
+    private long cachedWorldsGeneration = Long.MIN_VALUE;
 
     public static LazyWorldLocation of(Location location) {
         if (location instanceof LazyWorldLocation)

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/LazyWorldLocation.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/LazyWorldLocation.java
@@ -8,6 +8,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * LazyWorldLocation will update the world again if it's null on initialize.
  */
@@ -17,7 +19,7 @@ public class LazyWorldLocation extends Location {
      * Incremented every time a world is unloaded. Cached world references that were resolved
      * with an older generation must be resolved again, as they may point to an unloaded world.
      */
-    private static long worldsGeneration = Long.MIN_VALUE;
+    private static final AtomicLong worldsGeneration = new AtomicLong(Long.MIN_VALUE);
 
     @Nullable
     private String worldName;
@@ -65,7 +67,7 @@ public class LazyWorldLocation extends Location {
 
     @Override
     public World getWorld() {
-        if (!this.updatedWorld || this.cachedWorldsGeneration != worldsGeneration) {
+        if (!this.updatedWorld || this.cachedWorldsGeneration != worldsGeneration.get()) {
             updateWorldInternal(worldName == null ? null : Bukkit.getWorld(worldName));
         }
 
@@ -81,7 +83,7 @@ public class LazyWorldLocation extends Location {
     private void updateWorldInternal(@Nullable World world) {
         super.setWorld(world);
         this.updatedWorld = true;
-        this.cachedWorldsGeneration = worldsGeneration;
+        this.cachedWorldsGeneration = worldsGeneration.get();
     }
 
     @Override
@@ -100,7 +102,7 @@ public class LazyWorldLocation extends Location {
      * world throws an exception - its chunk-system is shut down.
      */
     public static void notifyWorldUnloaded() {
-        ++worldsGeneration;
+        worldsGeneration.incrementAndGet();
     }
 
     /**

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/stackedblocks/StackedBlock.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/stackedblocks/StackedBlock.java
@@ -66,7 +66,13 @@ public class StackedBlock {
         }
 
         World world = this.location.getWorld();
-        if (world == null)
+        // The world may have been unloaded while the stacked block is still tracked.
+        if (!LazyWorldLocation.isWorldLoaded(world))
+            return;
+
+        // We do not want to force-load the chunk of the block just to update its hologram.
+        // On unloaded worlds such a request throws an exception, as their chunk-system is shut down.
+        if (!world.isChunkLoaded(this.location.getBlockX() >> 4, this.location.getBlockZ() >> 4))
             return;
 
         Key currentBlockKey = Keys.of(location.getBlock());

--- a/src/main/java/com/bgsoftware/superiorskyblock/listener/ChunksListener.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/listener/ChunksListener.java
@@ -10,6 +10,7 @@ import com.bgsoftware.superiorskyblock.api.wrappers.BlockPosition;
 import com.bgsoftware.superiorskyblock.core.ChunkPosition;
 import com.bgsoftware.superiorskyblock.core.IslandWorldsPlayersStrategy;
 import com.bgsoftware.superiorskyblock.core.LazyReference;
+import com.bgsoftware.superiorskyblock.core.LazyWorldLocation;
 import com.bgsoftware.superiorskyblock.core.ObjectsPools;
 import com.bgsoftware.superiorskyblock.core.mutable.MutableBoolean;
 import com.bgsoftware.superiorskyblock.core.threads.BukkitExecutor;
@@ -64,6 +65,12 @@ public class ChunksListener extends AbstractGameEventListener {
     }
 
     private void onWorldUnload(GameEvent<GameEventArgs.WorldUnloadEvent> e) {
+        // Cached world references may point to the unloaded world, which cannot be accessed anymore.
+        // The world is only removed from the server after this event is handled, therefore we invalidate
+        // the cached references again on the next tick so they cannot be resolved to the unloaded world.
+        LazyWorldLocation.notifyWorldUnloaded();
+        BukkitExecutor.sync(LazyWorldLocation::notifyWorldUnloaded, 1L);
+
         // We do not care about spawn island, and therefore only island worlds are relevant.
         if (!plugin.getGrid().isIslandsWorld(e.getArgs().world))
             return;
@@ -156,13 +163,13 @@ public class ChunksListener extends AbstractGameEventListener {
         }
 
         BukkitExecutor.sync(() -> {
-            if (chunk.isLoaded())
+            if (isChunkStillLoaded(chunk))
                 // Update holograms of stacked blocks in delay so the chunk is entirely loaded.
                 plugin.getStackedBlocks().updateStackedBlockHolograms(chunk);
         }, 10L);
 
         BukkitExecutor.sync(() -> {
-            if (!pendingLoadedChunksForIsland.remove(chunk) || !chunk.isLoaded())
+            if (!pendingLoadedChunksForIsland.remove(chunk) || !isChunkStillLoaded(chunk))
                 return;
 
             // If we cannot recalculate entities at this moment, we want to track entities normally.
@@ -187,6 +194,12 @@ public class ChunksListener extends AbstractGameEventListener {
         }, 2L);
 
         DefaultIslandCalculationAlgorithm.CACHED_CALCULATED_CHUNKS.write(cache -> cache.remove(chunkPosition));
+    }
+
+    private static boolean isChunkStillLoaded(Chunk chunk) {
+        // Chunk#isLoaded may still report chunks of unloaded worlds as loaded, while accessing them
+        // throws an exception as the chunk-system of their world is shut down.
+        return LazyWorldLocation.isWorldLoaded(chunk.getWorld()) && chunk.isLoaded();
     }
 
     private static boolean isOldHologram(ArmorStand armorStand) {


### PR DESCRIPTION
Delayed chunk tasks could run after their world was unloaded, in which case accessing blocks threw as the chunk-system of the world is shut down. Cached world references of lazy locations are now invalidated when a world is unloaded, and stacked block holograms no longer force-load chunks.

Fixes:
`[18:58:43 WARN]: [SuperiorSkyblock2] Task #4563323 for SuperiorSkyblock2 v2026.2-b880 generated an exception java.lang.IllegalStateException: Chunk system has shut down, cannot process chunk requests in world 'island_xxxxxxxxxxx_normal' at (-3,2) status: minecraft:full at net.minecraft.server.level.ServerChunkCache.syncLoad(ServerChunkCache.java:114) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.server.level.ServerChunkCache.getChunkFallback(ServerChunkCache.java:155) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.server.level.ServerChunkCache.getChunk(ServerChunkCache.java:332) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.world.level.Level.getChunk(Level.java:1071) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.world.level.Level.getBlockState(Level.java:1339) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at org.bukkit.craftbukkit.block.CraftBlock.getType(CraftBlock.java:230) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.core.key.Keys.of(Keys.java:65) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.core.stackedblocks.StackedBlock.updateName(StackedBlock.java:72) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.core.stackedblocks.StackedBlocksManagerImpl.lambda$updateStackedBlockHolograms$4(StackedBlocksManagerImpl.java:237) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.core.collections.Location2ObjectMap.forEach(Location2ObjectMap.java:163) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.core.stackedblocks.container.DefaultStackedBlocksContainer.forEach(DefaultStackedBlocksContainer.java:40) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.core.stackedblocks.StackedBlocksManagerImpl.updateStackedBlockHolograms(StackedBlocksManagerImpl.java:236) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at SuperiorSkyblock2-2026.2-b880.jar/com.bgsoftware.superiorskyblock.listener.ChunksListener.lambda$handleIslandChunkLoad$3(ChunksListener.java:163) ~[SuperiorSkyblock2-2026.2-b880.jar:?] at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1678) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1546) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1268) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[aspaper-1.21.8.jar:1.21.8-16775-5a75226] at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?] `