### PR TITLE
Added parsing MemberRoleButton in MenuMemberManage

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuMemberManage.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuMemberManage.java
@@ -1,6 +1,5 @@
 package com.bgsoftware.superiorskyblock.core.menu.impl;
 
-import com.bgsoftware.superiorskyblock.core.menu.MenuSlotsMap;
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
 import com.bgsoftware.superiorskyblock.api.menu.layout.MenuLayout;
@@ -10,6 +9,7 @@ import com.bgsoftware.superiorskyblock.core.menu.parser.MenuParserImpl;
 import com.bgsoftware.superiorskyblock.core.menu.AbstractMenu;
 import com.bgsoftware.superiorskyblock.core.menu.MenuIdentifiers;
 import com.bgsoftware.superiorskyblock.core.menu.MenuParseResult;
+import com.bgsoftware.superiorskyblock.core.menu.MenuSlotsMap;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.MemberManageButton;
 import com.bgsoftware.superiorskyblock.core.menu.converter.MenuConverter;
 import com.bgsoftware.superiorskyblock.core.menu.layout.AbstractMenuLayout;
@@ -56,6 +56,8 @@ public class MenuMemberManage extends AbstractMenu<PlayerMenuView, PlayerViewArg
                 new MemberManageButton.Builder().setManageAction(MemberManageButton.ManageAction.BAN_MEMBER));
         patternBuilder.mapButtons(MenuParserImpl.getInstance().parseButtonSlots(cfg, "kick", menuSlotsMap),
                 new MemberManageButton.Builder().setManageAction(MemberManageButton.ManageAction.KICK_MEMBER));
+
+        MenuMemberRole.parseMemberRoleButton("member-manage.yml", menuSlotsMap, cfg, patternBuilder);
 
         return new MenuMemberManage(menuParseResult);
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuMemberRole.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuMemberRole.java
@@ -54,6 +54,13 @@ public class MenuMemberRole extends AbstractMenu<PlayerMenuView, PlayerViewArgs>
         YamlConfiguration cfg = menuParseResult.getConfig();
         MenuLayout.Builder<PlayerMenuView> patternBuilder = menuParseResult.getLayoutBuilder();
 
+        parseMemberRoleButton("member-role.yml", menuSlotsMap, cfg, patternBuilder);
+
+        return new MenuMemberRole(menuParseResult);
+    }
+
+    public static void parseMemberRoleButton(String fileName, MenuSlotsMap menuSlotsMap, YamlConfiguration cfg,
+                                              MenuLayout.Builder<PlayerMenuView> patternBuilder) {
         if (cfg.isConfigurationSection("items")) {
             for (String itemsSectionName : cfg.getConfigurationSection("items").getKeys(false)) {
                 ConfigurationSection itemsSection = cfg.getConfigurationSection("items." + itemsSectionName);
@@ -66,26 +73,25 @@ public class MenuMemberRole extends AbstractMenu<PlayerMenuView, PlayerViewArgs>
                     try {
                         playerRole = SPlayerRole.of((String) roleObject);
                     } catch (IllegalArgumentException error) {
-                        Log.warnFromFile("member-role.yml", "Invalid role name: ", roleObject);
+                        Log.warnFromFile(fileName, "Invalid role name: ", roleObject);
                         continue;
                     }
                 } else if (roleObject instanceof Integer) {
                     playerRole = SPlayerRole.of((Integer) roleObject);
                     if (playerRole == null) {
-                        Log.warnFromFile("member-role.yml", "&cInvalid role id: ", roleObject);
+                        Log.warnFromFile(fileName, "&cInvalid role id: ", roleObject);
                         continue;
                     }
                 }
 
-                if (playerRole == null)
+                if (playerRole == null) {
                     continue;
+                }
 
                 patternBuilder.mapButtons(menuSlotsMap.getSlots(itemsSectionName),
                         new MemberRoleButton.Builder().setPlayerRole(playerRole));
             }
         }
-
-        return new MenuMemberRole(menuParseResult);
     }
 
     private static boolean convertOldGUI(SuperiorSkyblockPlugin plugin, YamlConfiguration newMenu) {


### PR DESCRIPTION
As suggested in https://github.com/BG-Software-LLC/SuperiorSkyblock2/discussions/1106, but we can't just merge these menus, because we need to maintain backward compatibility, so I just added the option to parse this button in both menus.