### PR TITLE
Removed support for legacy "key:value" lists

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -64,7 +64,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 public class SettingsContainer {
@@ -265,32 +264,35 @@ public class SettingsContainer {
         maxIslandSize = config.getInt("max-island-size", 200);
         defaultIslandSize = Math.max(config.getInt("default-values.island-size", 20), 1);
         KeyMap<Integer> defaultBlockLimits = KeyMaps.createArrayMap(KeyIndicator.MATERIAL);
-        loadListOrSection(config, "default-values.block-limits", "block limit", (key, limit) -> {
+        for (String blockName : config.getConfigurationSection("default-values.block-limits").getKeys(false)) {
+            int limit = config.getInt("default-values.block-limits." + blockName);
             if (limit >= 0) {
-                Key blockKey = Keys.ofMaterialAndData(key);
-                defaultBlockLimits.put(blockKey, limit);
-                plugin.getBlockValues().addCustomBlockKey(blockKey);
+                Key materialKey = Keys.ofMaterialAndData(blockName);
+                defaultBlockLimits.put(materialKey, limit);
+                plugin.getBlockValues().addCustomBlockKey(materialKey);
             }
-        });
+        }
         this.defaultBlockLimits = KeyMaps.unmodifiableKeyMap(defaultBlockLimits);
         KeyMap<Integer> defaultEntityLimits = KeyMaps.createArrayMap(KeyIndicator.ENTITY_TYPE);
-        loadListOrSection(config, "default-values.entity-limits", "entity limit", (entityType, limit) -> {
+        for (String entityName : config.getConfigurationSection("default-values.entity-limits").getKeys(false)) {
+            int limit = config.getInt("default-values.entity-limits." + entityName);
             if (limit >= 0) {
-                defaultEntityLimits.put(Keys.ofEntityType(entityType), limit);
+                defaultEntityLimits.put(Keys.ofEntityType(entityName), limit);
             }
-        });
+        }
         this.defaultEntityLimits = KeyMaps.unmodifiableKeyMap(defaultEntityLimits);
         Map<PotionEffectType, Integer> defaultIslandEffects = new ArrayMap<>();
-        loadListOrSection(config, "default-values.island-effects", "island effect", (effectName, effectLevel) -> {
-            if (effectLevel >= 1) {
+        for (String effectName : config.getConfigurationSection("default-values.island-effects").getKeys(false)) {
+            int level = config.getInt("default-values.island-effects." + effectName);
+            if (level >= 0) {
                 PotionEffectType potionEffectType = PotionEffectType.getByName(effectName);
                 if (potionEffectType == null) {
                     Log.errorFromFile("config.yml", "Invalid potion effect " + effectName + ", skipping...");
                 } else {
-                    defaultIslandEffects.put(potionEffectType, effectLevel - 1);
+                    defaultIslandEffects.put(potionEffectType, level - 1);
                 }
             }
-        });
+        }
         this.defaultIslandEffects = Collections.unmodifiableMap(defaultIslandEffects);
         defaultTeamLimit = Math.max(config.getInt("default-values.team-limit", 4), IslandUpgradeConstants.NO_LIMIT_VALUE);
         defaultWarpsLimit = Math.max(config.getInt("default-values.warps-limit", 3), IslandUpgradeConstants.NO_LIMIT_VALUE);
@@ -300,15 +302,16 @@ public class SettingsContainer {
         defaultMobDrops = Math.max(config.getDouble("default-values.mob-drops", 1D), IslandUpgradeConstants.NO_LIMIT_VALUE);
         defaultBankLimit = new BigDecimal(config.getString("default-values.bank-limit", "-1")).max(IslandUpgradeConstants.NO_BANK_LIMIT_VALUE);
         defaultRoleLimits = CollectionsFactory.createInt2IntHashMap();
-        loadListOrSection(config, "default-values.role-limits", "role limit", (role, limit) -> {
+        for (String roleId : config.getConfigurationSection("default-values.role-limits").getKeys(false)) {
+            int limit = config.getInt("default-values.role-limits." + roleId);
             if (limit >= 0) {
                 try {
-                    defaultRoleLimits.put(Integer.parseInt(role), limit);
+                    defaultRoleLimits.put(Integer.parseInt(roleId), limit);
                 } catch (NumberFormatException error) {
-                    Log.warnFromFile("config.yml", "Invalid role id for limit: " + role);
+                    Log.warnFromFile("config.yml", "Invalid role id for limit: " + roleId + ", skipping...");
                 }
             }
-        });
+        }
         islandsHeight = config.getInt("islands-height", 100);
         worldBordersEnabled = config.getBoolean("world-borders", true);
         stackedBlocksEnabled = config.getBoolean("stacked-blocks.enabled", true);
@@ -316,10 +319,10 @@ public class SettingsContainer {
         whitelistedStackedBlocks = KeySets.createHashSet(KeyIndicator.MATERIAL, config.getStringList("stacked-blocks.whitelisted"));
         stackedBlocksName = Formatters.COLOR_FORMATTER.format(config.getString("stacked-blocks.custom-name"));
         KeyMap<Integer> stackedBlocksLimits = KeyMaps.createArrayMap(KeyIndicator.MATERIAL);
-        loadListOrSection(config, "stacked-blocks.limits", "stacked-block limit", (key, limit) -> {
-            Key blockKey = Keys.ofMaterialAndData(key);
-            stackedBlocksLimits.put(blockKey, limit);
-        });
+        for (String materialName : config.getConfigurationSection("stacked-blocks.limits").getKeys(false)) {
+            int limit = config.getInt("stacked-blocks.limits." + materialName);
+            stackedBlocksLimits.put(Keys.ofMaterialAndData(materialName), limit);
+        }
         this.stackedBlocksLimits = KeyMaps.unmodifiableKeyMap(stackedBlocksLimits);
         stackedBlocksAutoPickup = config.getBoolean("stacked-blocks.auto-collect", false);
         stackedBlocksMenuEnabled = config.getBoolean("stacked-blocks.deposit-menu.enabled", true);
@@ -384,10 +387,13 @@ public class SettingsContainer {
         visitorsDamage = config.getBoolean("visitors-damage", false);
         coopDamage = config.getBoolean("coop-damage", true);
         islandTopIncludeLeader = config.getBoolean("island-top-include-leader", true);
-        defaultPlaceholders = Collections.unmodifiableMap(config.getStringList("default-placeholders").stream().collect(Collectors.toMap(
-                line -> line.split(":")[0].replace("superior_", "").toLowerCase(Locale.ENGLISH),
-                line -> line.split(":")[1]
-        )));
+        Map<String, String> defaultPlaceholders = new HashMap<>();
+        for (String placeholderName : config.getConfigurationSection("default-placeholders").getKeys(false)) {
+            String placeholder = placeholderName.replace("superior_", "").toLowerCase(Locale.ENGLISH);
+            String replacement = config.getString("default-placeholders." + placeholder);
+            defaultPlaceholders.put(placeholder, replacement);
+        }
+        this.defaultPlaceholders = Collections.unmodifiableMap(defaultPlaceholders);
         banConfirm = config.getBoolean("ban-confirm");
         disbandConfirm = config.getBoolean("disband-confirm");
         kickConfirm = config.getBoolean("kick-confirm");
@@ -416,17 +422,21 @@ public class SettingsContainer {
         defaultSettings = Collections.unmodifiableList(config.getStringList("default-settings")
                 .stream().map(str -> str.toUpperCase(Locale.ENGLISH)).collect(Collectors.toList()));
         defaultGenerator = new EnumerateMap<>(Dimension.values());
-        if (config.isConfigurationSection("default-values.generator")) {
-            for (String env : config.getConfigurationSection("default-values.generator").getKeys(false)) {
-                try {
-                    Dimension dimension = Dimension.getByName(env.toUpperCase(Locale.ENGLISH));
-                    loadGenerator(config, "default-values.generator." + env, dimension);
-                } catch (Exception error) {
-                    Log.errorFromFile(error, "config.yml", "An unexpected error occurred while loading default generator values for ", env + ":");
+        for (String dimensionName : config.getConfigurationSection("default-values.generator").getKeys(false)) {
+            try {
+                Dimension dimension = Dimension.getByName(dimensionName.toUpperCase(Locale.ENGLISH));
+
+                KeyMap<Integer> defaultGenerator = KeyMaps.createArrayMap(KeyIndicator.MATERIAL);
+                for (String materialName : config.getConfigurationSection("default-values.generator." + dimensionName).getKeys(false)) {
+                    int percentage = config.getInt("default-values.generator." + dimensionName + "." + materialName);
+                    if (percentage >= 0) {
+                        defaultGenerator.put(Keys.ofMaterialAndData(materialName), percentage);
+                    }
                 }
+                this.defaultGenerator.put(dimension, KeyMaps.unmodifiableKeyMap(defaultGenerator));
+            } catch (Exception error) {
+                Log.errorFromFile(error, "config.yml", "An unexpected error occurred while loading default generator values for ", dimensionName + ":");
             }
-        } else {
-            loadGenerator(config, "default-values.generator", this.defaultWorldDimension);
         }
         disableRedstoneOffline = config.getBoolean("disable-redstone-offline", true);
         disableRedstoneAFK = config.getBoolean("afk-integrations.disable-redstone", false);
@@ -747,43 +757,6 @@ public class SettingsContainer {
         }
 
         return KeySets.unmodifiableKeySet(KeySets.createHashSet(KeyIndicator.MATERIAL, safeBlocks));
-    }
-
-    private void loadGenerator(YamlConfiguration config, String path, Dimension dimension) {
-        KeyMap<Integer> defaultGenerator = KeyMaps.createArrayMap(KeyIndicator.MATERIAL);
-        loadListOrSection(config, path, "generator-rates", (key, percentage) -> {
-            if (percentage >= 0) {
-                Key blockKey = Keys.ofMaterialAndData(key);
-                defaultGenerator.put(blockKey, percentage);
-            }
-        });
-        this.defaultGenerator.put(dimension, KeyMaps.unmodifiableKeyMap(defaultGenerator));
-    }
-
-    private static void loadListOrSection(YamlConfiguration config, String path, String parseName, BiConsumer<String, Integer> consumer) {
-        Object value = config.get(path);
-        if (value == null)
-            return;
-
-        if (value instanceof List) {
-            ((List<String>) value).forEach(line -> {
-                String[] sections = line.split(":");
-                if (sections.length == 2) {
-                    consumer.accept(sections[0], Integer.parseInt(sections[1]));
-                } else if (sections.length == 3) {
-                    consumer.accept(sections[0] + ":" + sections[1], Integer.parseInt(sections[2]));
-                } else {
-                    Log.warnFromFile("config.yml", "Cannot parse " + parseName + " '", line, "', skipping...");
-                }
-            });
-
-        } else if (value instanceof ConfigurationSection) {
-            for (String key : ((ConfigurationSection) value).getKeys(false)) {
-                consumer.accept(key, ((ConfigurationSection) value).getInt(key));
-            }
-        } else {
-            throw new IllegalArgumentException("Value of path '" + path + "' is not a list or a section, but " + value.getClass());
-        }
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsManagerImpl.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @SuppressWarnings("WeakerAccess")
 public class SettingsManagerImpl extends Manager implements SettingsManager {
@@ -53,7 +54,7 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
     private static final String[] IGNORED_SECTIONS = new String[]{
             "config.yml", "ladder", "commands-cooldown", "containers", "event-commands", "command-aliases", "worlds.dimensions",
             "island-previews.locations", "default-values.block-limits", "default-values.entity-limits",
-            "default-values.role-limits", "stacked-blocks.limits", "default-values.generator", "message-delays"
+            "default-values.role-limits", "stacked-blocks.limits", "default-values.generator", "message-delays", "default-placeholders"
     };
 
     private final GlobalSection global = new GlobalSection();
@@ -83,7 +84,15 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
             plugin.saveResource("config.yml", false);
 
         CommentedConfiguration cfg = CommentedConfiguration.loadConfiguration(file);
-        convertData(cfg);
+
+        if (convertData(cfg)) {
+            try {
+                cfg.save(file);
+            } catch (Exception error) {
+                Log.error(error, file, "An unexpected error occurred while loading config file:");
+            }
+        }
+
         convertInteractables(plugin, cfg);
         convertEntityCategories(plugin, cfg);
 
@@ -759,7 +768,9 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
         this.islandPreviews.setContainer(container);
     }
 
-    private void convertData(YamlConfiguration cfg) {
+    private boolean convertData(YamlConfiguration cfg) {
+        AtomicBoolean converted = new AtomicBoolean(false);
+
         if (cfg.getConfigurationSection("worlds.dimensions") == null) {
             cfg.set("worlds.dimensions.normal", cfg.getConfigurationSection("worlds.normal"));
             cfg.set("worlds.dimensions.normal.environment", "NORMAL");
@@ -894,8 +905,63 @@ public class SettingsManagerImpl extends Manager implements SettingsManager {
         if (cfg.isBoolean("worlds.end.dragon-fight")) {
             cfg.set("worlds.end.dragon-fight.enabled", cfg.getBoolean("worlds.end.dragon-fight"));
         }
-        if (!cfg.isConfigurationSection("default-values.island-effects"))
+        if (cfg.get("default-values.island-effects") == null) {
             cfg.createSection("default-values.island-effects");
+        }
+        convertListToSection(cfg, "default-values.block-limits", true, converted);
+        convertListToSection(cfg, "default-values.entity-limits", true, converted);
+        convertListToSection(cfg, "default-values.island-effects", true, converted);
+        convertListToSection(cfg, "default-values.role-limits", true, converted);
+        convertListToSection(cfg, "stacked-blocks.limits", true, converted);
+        convertListToSection(cfg, "default-placeholders", false, converted);
+        if (cfg.isConfigurationSection("worlds.dimensions")) {
+            boolean hasDimensionalGeneratorRates = false;
+
+            for (String dimension : cfg.getConfigurationSection("worlds.dimensions").getKeys(false)) {
+                if (cfg.contains("default-values.generator." + dimension)) {
+                    convertListToSection(cfg, "default-values.generator." + dimension, true, converted);
+                    hasDimensionalGeneratorRates = true;
+                }
+            }
+
+            if (!hasDimensionalGeneratorRates) {
+                Object generator = cfg.get("default-values.generator");
+                String defaultDimension = cfg.getString("worlds.default-world");
+                cfg.set("default-values.generator." + defaultDimension, generator);
+                convertListToSection(cfg, "default-values.generator." + defaultDimension, true, converted);
+            }
+        }
+
+        return converted.get();
+    }
+
+    private void convertListToSection(YamlConfiguration cfg, String path, boolean integers, AtomicBoolean converted) {
+        if (cfg.isList(path)) {
+            List<String> list = cfg.getStringList(path);
+
+            cfg.set(path, null);
+
+            for (String line : list) {
+                String[] sections = line.split(":");
+
+                String key;
+                String value;
+                if (sections.length == 2) {
+                    key = sections[0];
+                    value = sections[1];
+                } else if (sections.length == 3) {
+                    key = sections[0] + ":" + sections[1];
+                    value = sections[2];
+                } else {
+                    Log.warnFromFile("config.yml", "Cannot parse value '", line, "', skipping...");
+                    continue;
+                }
+
+                cfg.set(path + "." + key, integers ? Integer.parseInt(value) : value);
+            }
+
+            converted.set(true);
+        }
     }
 
     private void convertInteractables(SuperiorSkyblockPlugin plugin, YamlConfiguration cfg) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -464,12 +464,11 @@ coop-damage: true
 island-top-include-leader: true
 
 # Set default placeholders that will be returned if the island is null.
-# Please use the <placeholder>:<default> format.
 # You can find a list of placeholders here: https://bg-software.com/superiorskyblock/#placeholders
 default-placeholders:
-  - 'superior_island_leader:N/A'
-  - 'superior_island_level:0'
-  - 'superior_island_worth:0'
+  'superior_island_leader': 'N/A'
+  'superior_island_level': '0'
+  'superior_island_worth': '0'
 
 # Should a confirm gui be displayed when /is ban is executed.
 ban-confirm: true


### PR DESCRIPTION
# Changelog #
- Removed support for using "key:value" lists instead of sections in the main configuration file (mostly in default-values). Since newly created configurations no longer support this legacy method, the main configuration has been updated to match for the sake of consistency. However, a converter has been added to transform old lists into sections.
- Added a converter for the "default-values.generator" section if it lacks any dimension definitions, this replaces the previous approach of checking the section and setting values ​​for the default dimension every time the configuration was loaded.
- Changed the loading mechanism for the "default-placeholders" from "key:value" lists to sections to ensure consistency with other options. The old format is also automatically converted.