### PR TITLE
Added the ability to display paged buttons in more than one slot

### DIFF
--- a/API/src/main/java/com/bgsoftware/superiorskyblock/api/menu/layout/PagedMenuLayout.java
+++ b/API/src/main/java/com/bgsoftware/superiorskyblock/api/menu/layout/PagedMenuLayout.java
@@ -66,6 +66,13 @@ public interface PagedMenuLayout<V extends MenuView<V, ?>> extends MenuLayout<V>
         Builder<V, E> setCustomLayoutOrder(List<Integer> slotsOrder);
 
         /**
+         * Set a custom order and slot layout for the paged objects.
+         *
+         * @param slotsLayout The correct layout of the slots
+         */
+        Builder<V, E> setCustomLayout(List<List<Integer>> slotsLayout);
+
+        /**
          * Get the {@link PagedMenuLayout} from this builder.
          */
         @Override

--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdBiome.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/player/CmdBiome.java
@@ -1,6 +1,6 @@
 package com.bgsoftware.superiorskyblock.commands.player;
 
-import com.bgsoftware.superiorskyblock.api.enums.DimensionSelectionMode;
+import com.bgsoftware.superiorskyblock.island.biome.DimensionSelectionMode;
 import com.bgsoftware.superiorskyblock.api.world.Dimension;
 import com.bgsoftware.superiorskyblock.commands.CommandTabCompletes;
 import com.bgsoftware.superiorskyblock.commands.IPermissibleCommand;

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuBiomes.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/impl/MenuBiomes.java
@@ -3,7 +3,7 @@ package com.bgsoftware.superiorskyblock.core.menu.impl;
 import com.bgsoftware.common.annotations.NotNull;
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
-import com.bgsoftware.superiorskyblock.api.enums.DimensionSelectionMode;
+import com.bgsoftware.superiorskyblock.island.biome.DimensionSelectionMode;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.menu.Menu;
 import com.bgsoftware.superiorskyblock.api.menu.view.MenuView;
@@ -35,8 +35,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -354,9 +356,11 @@ public class MenuBiomes extends AbstractPagedMenu<MenuBiomes.View, MenuBiomes.Ar
         if (!biomeChars.isEmpty()) {
             List<String> pattern = cfg.getStringList("pattern");
             List<String> newPattern = new ArrayList<>(pattern.size());
+            Map<Character, List<Integer>> biomeSlots = new LinkedHashMap<>();
 
             char newChar = biomeChars.iterator().next();
 
+            int slot = 0;
             for (String line : pattern) {
                 StringBuilder newLine = new StringBuilder();
                 char[] chars = line.replace(" ", "").toCharArray();
@@ -365,11 +369,33 @@ public class MenuBiomes extends AbstractPagedMenu<MenuBiomes.View, MenuBiomes.Ar
                     char ch = chars[i];
                     newLine.append(biomeChars.contains(ch) ? newChar : ch);
 
-                    if (i < chars.length - 1)
+                    if (i < chars.length - 1) {
                         newLine.append(" ");
+                    }
+
+                    if (biomeChars.contains(ch)) {
+                        biomeSlots.computeIfAbsent(ch, key -> new ArrayList<>()).add(slot);
+                    }
+
+                    slot++;
                 }
 
                 newPattern.add(newLine.toString());
+            }
+
+            if (!biomeSlots.isEmpty()) {
+                boolean shouldChangeLayout = false;
+
+                for (List<Integer> slots : biomeSlots.values()) {
+                    if (slots.size() > 1) {
+                        shouldChangeLayout = true;
+                        break;
+                    }
+                }
+
+                if (shouldChangeLayout) {
+                    cfg.set("custom-layout", new ArrayList<>(biomeSlots.values()));
+                }
             }
 
             cfg.set("pattern", newPattern);

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/PagedDialogMenuLayoutImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/PagedDialogMenuLayoutImpl.java
@@ -1,22 +1,17 @@
 package com.bgsoftware.superiorskyblock.core.menu.layout;
 
 import com.bgsoftware.common.annotations.Nullable;
-import com.bgsoftware.superiorskyblock.api.menu.button.MenuTemplateButton;
 import com.bgsoftware.superiorskyblock.api.menu.button.PagedMenuTemplateButton;
-import com.bgsoftware.superiorskyblock.api.menu.dialog.DialogMenuType;
-import com.bgsoftware.superiorskyblock.api.menu.layout.MenuLayout;
 import com.bgsoftware.superiorskyblock.api.menu.layout.PagedDialogMenuLayout;
-import com.bgsoftware.superiorskyblock.api.menu.layout.PagedInventoryMenuLayout;
-import com.bgsoftware.superiorskyblock.api.menu.layout.PagedMenuLayout;
-import com.bgsoftware.superiorskyblock.api.menu.view.MenuView;
 import com.bgsoftware.superiorskyblock.api.menu.view.PagedMenuView;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.CurrentPageButton;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.NextPageButton;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.PreviousPageButton;
-import com.bgsoftware.superiorskyblock.core.menu.layout.order.CustomPagedLayoutOrder;
-import com.bgsoftware.superiorskyblock.core.menu.layout.order.PagedLayoutOrder;
-import org.bukkit.event.inventory.InventoryType;
+import com.bgsoftware.superiorskyblock.core.menu.layout.custom.CustomPagedLayout;
+import com.bgsoftware.superiorskyblock.core.menu.layout.custom.PagedLayout;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PagedDialogMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> extends RegularDialogMenuLayoutImpl<V> implements PagedDialogMenuLayout<V> {
@@ -35,7 +30,7 @@ public class PagedDialogMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> exte
             implements PagedDialogMenuLayout.Builder<V, E> {
 
         @Nullable
-        private PagedLayoutOrder<V> layoutOrder;
+        private PagedLayout<V> layoutOrder;
 
         @Override
         public Builder<V, E> setPreviousPageSlots(List<Integer> slots) {
@@ -63,9 +58,45 @@ public class PagedDialogMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> exte
 
         @Override
         public Builder<V, E> setCustomLayoutOrder(List<Integer> slotsOrder) {
-            slotsOrder.removeIf(slot -> !(super.buttons[slot] instanceof PagedMenuTemplateButton));
-            if (!slotsOrder.isEmpty())
-                this.layoutOrder = new CustomPagedLayoutOrder<>(slotsOrder);
+            List<List<Integer>> validSlotsLayout = new ArrayList<>();
+
+            for (int slot : slotsOrder) {
+                if (slot >= 0 && slot < super.buttons.length &&
+                        super.buttons[slot] instanceof PagedMenuTemplateButton) {
+                    validSlotsLayout.add(Collections.singletonList(slot));
+                }
+            }
+
+            if (!validSlotsLayout.isEmpty()) {
+                this.layoutOrder = new CustomPagedLayout<>(validSlotsLayout);
+            }
+
+            return this;
+        }
+
+        @Override
+        public Builder<V, E> setCustomLayout(List<List<Integer>> slotsLayout) {
+            List<List<Integer>> validSlotsLayout = new ArrayList<>();
+
+            for (List<Integer> slots : slotsLayout) {
+                List<Integer> validSlots = new ArrayList<>();
+
+                for (int slot : slots) {
+                    if (slot >= 0 && slot < super.buttons.length &&
+                            super.buttons[slot] instanceof PagedMenuTemplateButton) {
+                        validSlots.add(slot);
+                    }
+                }
+
+                if (!validSlots.isEmpty()) {
+                    validSlotsLayout.add(validSlots);
+                }
+            }
+
+            if (!validSlotsLayout.isEmpty()) {
+                this.layoutOrder = new CustomPagedLayout<>(validSlotsLayout);
+            }
+
             return this;
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/PagedInventoryMenuLayoutImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/PagedInventoryMenuLayoutImpl.java
@@ -12,19 +12,21 @@ import com.bgsoftware.superiorskyblock.core.logging.Log;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.CurrentPageButton;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.NextPageButton;
 import com.bgsoftware.superiorskyblock.core.menu.button.impl.PreviousPageButton;
-import com.bgsoftware.superiorskyblock.core.menu.layout.order.CustomPagedLayoutOrder;
-import com.bgsoftware.superiorskyblock.core.menu.layout.order.PagedLayoutOrder;
+import com.bgsoftware.superiorskyblock.core.menu.layout.custom.CustomPagedLayout;
+import com.bgsoftware.superiorskyblock.core.menu.layout.custom.PagedLayout;
 import com.bgsoftware.superiorskyblock.core.mutable.MutableInt;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> extends RegularInventoryMenuLayoutImpl<V> implements PagedInventoryMenuLayout<V> {
 
     @Nullable
-    private final PagedLayoutOrder<V> customLayoutOrder;
+    private final PagedLayout<V> customLayoutOrder;
     private final int objectsPerPageCount;
 
     private PagedInventoryMenuLayoutImpl(Builder<V, E> builder) {
@@ -33,13 +35,21 @@ public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> e
         this.objectsPerPageCount = builder.layoutOrder == null ? countPagedButtons(buttons) : builder.layoutOrder.getObjectsPerPageCount();
         if (this.customLayoutOrder != null) {
             // Update button indexes with the custom layout order
-            PagedLayoutOrder.MenuButtonsIterator<V> buttonsIterator = this.customLayoutOrder.createIterator(this.buttons);
+            PagedLayout.MenuButtonsIterator<V> buttonsIterator = this.customLayoutOrder.createIterator(this.buttons);
             int buttonIndex = 0;
-            while (buttonsIterator.hasNext()) {
-                MenuTemplateButton<V> templateButton = buttonsIterator.next();
 
-                if (templateButton instanceof PagedMenuTemplateButton)
-                    ((PagedMenuTemplateButton<V, ?>) templateButton).setButtonIndex(buttonIndex++);
+            while (buttonsIterator.hasNext()) {
+                buttonsIterator.next();
+
+                for (int slot : buttonsIterator.getSlots()) {
+                    MenuTemplateButton<V> templateButton = this.buttons[slot];
+
+                    if (templateButton instanceof PagedMenuTemplateButton) {
+                        ((PagedMenuTemplateButton<V, ?>) templateButton).setButtonIndex(buttonIndex);
+                    }
+                }
+
+                buttonIndex++;
             }
         }
     }
@@ -57,32 +67,44 @@ public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> e
         for (int slot = 0; slot < this.buttons.length; ++slot) {
             MenuViewButton<V> button = this.buttons[slot].createViewButton(menuView);
 
-            if (this.customLayoutOrder != null && button instanceof PagedMenuViewButton)
+            if (this.customLayoutOrder != null && button instanceof PagedMenuViewButton) {
                 continue;
+            }
 
-            populateInventoryWithButton(inventory, button, slot, menuView, pagedObjectSlot);
+            ItemStack buttonItem = createButtonItem(button, menuView, pagedObjectSlot);
+
+            if (buttonItem != null) {
+                inventory.setItem(slot, buttonItem);
+            }
         }
 
-        if (this.customLayoutOrder == null)
+        if (this.customLayoutOrder == null) {
             return;
+        }
 
-        PagedLayoutOrder.MenuButtonsIterator<V> buttonsIterator = this.customLayoutOrder.createIterator(this.buttons);
+        PagedLayout.MenuButtonsIterator<V> buttonsIterator = this.customLayoutOrder.createIterator(this.buttons);
+
         while (buttonsIterator.hasNext()) {
             MenuTemplateButton<V> templateButton = buttonsIterator.next();
 
-            if (!(templateButton instanceof PagedMenuTemplateButton))
+            if (!(templateButton instanceof PagedMenuTemplateButton)) {
                 continue;
+            }
 
             MenuViewButton<V> button = templateButton.createViewButton(menuView);
-            int slot = buttonsIterator.getSlot();
+            ItemStack buttonItem = createButtonItem(button, menuView, pagedObjectSlot);
 
-            populateInventoryWithButton(inventory, button, slot, menuView, pagedObjectSlot);
+            if (buttonItem == null) {
+                continue;
+            }
+
+            for (int slot : buttonsIterator.getSlots()) {
+                inventory.setItem(slot, buttonItem);
+            }
         }
-
     }
 
-    private void populateInventoryWithButton(Inventory inventory, MenuViewButton<V> button, int slot,
-                                             PagedMenuView<V, ?, E> menuView, MutableInt pagedObjectSlot) {
+    private ItemStack createButtonItem(MenuViewButton<V> button, PagedMenuView<V, ?, E> menuView, MutableInt pagedObjectSlot) {
         int currentPage = menuView.getCurrentPage();
         List<E> pagedObjects = menuView.getPagedObjects();
 
@@ -93,11 +115,10 @@ public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> e
             pagedObjectSlot.set(pagedObjectSlot.get() + 1);
 
             if (objectIndex >= pagedObjects.size()) {
-                inventory.setItem(slot, ((PagedMenuTemplateButton<V, E>) pagedMenuButton.getTemplate()).getNullItem());
-                return;
-            } else {
-                pagedMenuButton.updateObject(pagedObjects.get(objectIndex));
+                return ((PagedMenuTemplateButton<V, E>) pagedMenuButton.getTemplate()).getNullItem();
             }
+
+            pagedMenuButton.updateObject(pagedObjects.get(objectIndex));
         }
 
         ItemStack buttonItem;
@@ -106,27 +127,28 @@ public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> e
             buttonItem = button.createViewItem();
         } catch (Exception error) {
             Log.error(error, "An unexpected error occurred while setting up menu:");
-            return;
+            return null;
         }
 
-        if (buttonItem == null)
-            return;
+        if (buttonItem == null) {
+            return null;
+        }
 
         if (button instanceof PreviousPageButton) {
-            inventory.setItem(slot, new ItemBuilder(buttonItem)
+            return new ItemBuilder(buttonItem)
                     .replaceAll("{0}", (currentPage == 1 ? "&c" : "&a"))
-                    .build(menuView.getInventoryViewer()));
+                    .build(menuView.getInventoryViewer());
         } else if (button instanceof NextPageButton) {
-            inventory.setItem(slot, new ItemBuilder(buttonItem)
+            return new ItemBuilder(buttonItem)
                     .replaceAll("{0}", (pagedObjects.size() > currentPage * this.objectsPerPageCount ? "&a" : "&c"))
-                    .build(menuView.getInventoryViewer()));
+                    .build(menuView.getInventoryViewer());
         } else if (button instanceof CurrentPageButton) {
-            inventory.setItem(slot, new ItemBuilder(buttonItem)
+            return new ItemBuilder(buttonItem)
                     .replaceAll("{0}", currentPage + "")
-                    .build(menuView.getInventoryViewer()));
-        } else {
-            inventory.setItem(slot, buttonItem);
+                    .build(menuView.getInventoryViewer());
         }
+
+        return buttonItem;
     }
 
     private static int countPagedButtons(MenuTemplateButton<?>[] buttons) {
@@ -138,7 +160,7 @@ public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> e
             implements PagedInventoryMenuLayout.Builder<V, E> {
 
         @Nullable
-        private PagedLayoutOrder<V> layoutOrder;
+        private PagedLayout<V> layoutOrder;
 
         @Override
         public Builder<V, E> setPreviousPageSlots(List<Integer> slots) {
@@ -166,9 +188,45 @@ public class PagedInventoryMenuLayoutImpl<V extends PagedMenuView<V, ?, E>, E> e
 
         @Override
         public Builder<V, E> setCustomLayoutOrder(List<Integer> slotsOrder) {
-            slotsOrder.removeIf(slot -> !(super.buttons[slot] instanceof PagedMenuTemplateButton));
-            if (!slotsOrder.isEmpty())
-                this.layoutOrder = new CustomPagedLayoutOrder<>(slotsOrder);
+            List<List<Integer>> validSlotsLayout = new ArrayList<>();
+
+            for (int slot : slotsOrder) {
+                if (slot >= 0 && slot < super.buttons.length &&
+                        super.buttons[slot] instanceof PagedMenuTemplateButton) {
+                    validSlotsLayout.add(Collections.singletonList(slot));
+                }
+            }
+
+            if (!validSlotsLayout.isEmpty()) {
+                this.layoutOrder = new CustomPagedLayout<>(validSlotsLayout);
+            }
+
+            return this;
+        }
+
+        @Override
+        public Builder<V, E> setCustomLayout(List<List<Integer>> slotsLayout) {
+            List<List<Integer>> validSlotsLayout = new ArrayList<>();
+
+            for (List<Integer> slots : slotsLayout) {
+                List<Integer> validSlots = new ArrayList<>();
+
+                for (int slot : slots) {
+                    if (slot >= 0 && slot < super.buttons.length &&
+                            super.buttons[slot] instanceof PagedMenuTemplateButton) {
+                        validSlots.add(slot);
+                    }
+                }
+
+                if (!validSlots.isEmpty()) {
+                    validSlotsLayout.add(validSlots);
+                }
+            }
+
+            if (!validSlotsLayout.isEmpty()) {
+                this.layoutOrder = new CustomPagedLayout<>(validSlotsLayout);
+            }
+
             return this;
         }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/custom/CustomPagedLayout.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/custom/CustomPagedLayout.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.core.menu.layout.order;
+package com.bgsoftware.superiorskyblock.core.menu.layout.custom;
 
 import com.bgsoftware.superiorskyblock.api.menu.button.MenuTemplateButton;
 import com.bgsoftware.superiorskyblock.api.menu.view.MenuView;
@@ -6,11 +6,11 @@ import com.bgsoftware.superiorskyblock.api.menu.view.MenuView;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CustomPagedLayoutOrder<T extends MenuView<T, ?>> implements PagedLayoutOrder<T> {
+public class CustomPagedLayout<T extends MenuView<T, ?>> implements PagedLayout<T> {
 
-    private final List<Integer> slotsOrder;
+    private final List<List<Integer>> slotsOrder;
 
-    public CustomPagedLayoutOrder(List<Integer> slotsOrder) {
+    public CustomPagedLayout(List<List<Integer>> slotsOrder) {
         this.slotsOrder = new ArrayList<>(slotsOrder);
     }
 
@@ -28,30 +28,39 @@ public class CustomPagedLayoutOrder<T extends MenuView<T, ?>> implements PagedLa
 
         private final MenuTemplateButton<T>[] buttons;
         private int cursor = 0;
-        private int currentSlot;
+        private List<Integer> currentSlots;
 
         private IteratorImpl(MenuTemplateButton<T>[] buttons) {
             this.buttons = buttons;
         }
 
         @Override
-        public int getSlot() {
-            return this.currentSlot;
+        public List<Integer> getSlots() {
+            return this.currentSlots;
         }
 
         @Override
         public boolean hasNext() {
-            if (this.cursor >= slotsOrder.size())
+            if (this.cursor >= slotsOrder.size()) {
                 return false;
+            }
 
-            int slot = slotsOrder.get(this.cursor);
-            return slot >= 0 && slot < this.buttons.length;
+            List<Integer> slots = slotsOrder.get(this.cursor);
+
+            for (int slot : slots) {
+                if (slot < 0 || slot >= this.buttons.length) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         @Override
         public MenuTemplateButton<T> next() {
-            this.currentSlot = slotsOrder.get(this.cursor++);
-            return this.buttons[this.currentSlot];
+            this.currentSlots = slotsOrder.get(this.cursor++);
+
+            return this.buttons[this.currentSlots.get(0)];
         }
 
     }

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/custom/PagedLayout.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/layout/custom/PagedLayout.java
@@ -1,11 +1,12 @@
-package com.bgsoftware.superiorskyblock.core.menu.layout.order;
+package com.bgsoftware.superiorskyblock.core.menu.layout.custom;
 
 import com.bgsoftware.superiorskyblock.api.menu.button.MenuTemplateButton;
 import com.bgsoftware.superiorskyblock.api.menu.view.MenuView;
 
 import java.util.Iterator;
+import java.util.List;
 
-public interface PagedLayoutOrder<T extends MenuView<T, ?>> {
+public interface PagedLayout<T extends MenuView<T, ?>> {
 
     int getObjectsPerPageCount();
 
@@ -13,7 +14,7 @@ public interface PagedLayoutOrder<T extends MenuView<T, ?>> {
 
     interface MenuButtonsIterator<T extends MenuView<T, ?>> extends Iterator<MenuTemplateButton<T>> {
 
-        int getSlot();
+        List<Integer> getSlots();
 
     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/core/menu/parser/MenuParserImpl.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/core/menu/parser/MenuParserImpl.java
@@ -26,6 +26,7 @@ import org.bukkit.event.inventory.InventoryType;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -101,8 +102,28 @@ public class MenuParserImpl implements MenuParser {
             inventoryMenuLayoutBuilder.setNextPageSlots(parseButtonSlots(cfg, "next-page", menuSlotsMap));
             inventoryMenuLayoutBuilder.setPagedObjectSlots(parseButtonSlots(cfg, "slots", menuSlotsMap), pagedButtonBuilder);
 
-            if (cfg.isList("custom-order"))
+            if (cfg.isList("custom-layout")) {
+                List<?> customLayout = cfg.getList("custom-layout");
+                List<List<Integer>> slotsLayout = new ArrayList<>();
+
+                for (Object element : customLayout) {
+                    if (element instanceof List<?>) {
+                        List<Integer> slots = new ArrayList<>();
+
+                        for (Object slot : (List<?>) element) {
+                            slots.add(((Number) slot).intValue());
+                        }
+
+                        slotsLayout.add(slots);
+                    }
+                }
+
+                if (!slotsLayout.isEmpty()) {
+                    inventoryMenuLayoutBuilder.setCustomLayout(slotsLayout);
+                }
+            } else if (cfg.isList("custom-order")) {
                 inventoryMenuLayoutBuilder.setCustomLayoutOrder(cfg.getIntegerList("custom-order"));
+            }
         }
 
         return new MenuParseResult<>(menuLayoutBuilder, openingSound, previousMoveAllowed, skipOneItem, menuSlotsMap, cfg);

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/biome/DimensionSelectionMode.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/biome/DimensionSelectionMode.java
@@ -1,4 +1,4 @@
-package com.bgsoftware.superiorskyblock.api.enums;
+package com.bgsoftware.superiorskyblock.island.biome;
 
 /**
  * Used to determine the dimension in which the player changes their island's biome.


### PR DESCRIPTION
As suggested in https://github.com/BG-Software-LLC/SuperiorSkyblock2/discussions/1977 but in a somewhat more expanded form.

# Changelog #
- Added the 'custom-layout' option, which extends the existing 'custom-order' option by allowing changes to the entire layout, so not just the order, but also the amount of occurrences of the paged button. Unlike 'custom-order', this takes a list of lists of integers rather than a simple list of integers, however, both options remain supported, since someone might only want to change the order, I gave them distinct names, and both will continue to function.
- In PagedInventoryMenuLayoutImpl.Builder, instead of removing objects from the original lists in setCustomLayoutOrder() and setCustomLayout(), I create copies of those lists and remove the unnecessary slots from them.
- For the recently created converter of the 'biomes' menu to a paged format, I also added a converter for the 'custom-layout' feature. The previous basic menu allowed a single biome to be displayed in multiple slots, a feature likely used by players who enjoy texture packs, but this option was missing in the paged version, consequently, I needed to add this capability for paged buttons and implement the corresponding converter for the 'biomes' menu.
- Moved the 'DimensionSelectionMode' enum from the API to Core. Since I intend to remove it in the upcoming Pull Request that adds the Visit and Warps modules, and because it hadn't yet been included in the official API, moving it now allows for its eventual removal without significant issues.