### PR TITLE
Fixed the granting of bank interest when the recent active time exceeded the interval time

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -400,7 +400,6 @@ public class SIsland implements Island {
         plugin.getBlockValues().addCustomBlockKeys(builder.blockLimits.keySet());
 
         updateDatesFormatter();
-        startBankInterest();
         checkMembersDuplication();
         updateOldUpgradeValues();
         updateUpgrades();
@@ -413,6 +412,10 @@ public class SIsland implements Island {
 
         this.islandBank.setBalance(builder.balance);
         builder.bankTransactions.forEach(this.islandBank::loadTransaction);
+
+        // We need to load the transactions and balance before the bank interest process starts.
+        startBankInterest();
+
         if (builder.persistentData.length > 0)
             getPersistentDataContainer().load(builder.persistentData);
 


### PR DESCRIPTION
Balance and transactions were loaded before the bank interest check, consequently, if `interest.recent-active` exceeded `interest.interval` in the bank module configuration, this could lead to the following situations: https://discord.com/channels/554276823010246687/554282577322704896/1541189734280331325 https://discord.com/channels/554276823010246687/554282577322704896/1541536010251538563

Example scenario: `interest.interval` set to 5 minutes, `interest.active-time` set to 10 minutes.
A player is active and receives interest, they wait `4 minutes` and leave the server. After `1 minute`, they receive interest again (because 1 < 10). Another `4 minutes` pass, and the server restarts, which taking `2 minutes`. During the island object creation, the interest condition is checked
```JAVA
    private void startBankInterest() {
        if (!BuiltinModules.BANK.getConfiguration().isBankInterestEnabled())
            return;

        int bankInterestInterval = BuiltinModules.BANK.getConfiguration().getBankInterestInterval();
        long currentTime = System.currentTimeMillis() / 1000;
        long ticksToNextInterest = (bankInterestInterval - (currentTime - this.lastInterest)) * 20;
        if (ticksToNextInterest <= 0) {
            giveInterest(true);
        } else {
            resetBankInterestTask(ticksToNextInterest);
        }
    }
```
, since a total of `6 minutes` (so > 5) have passed since the last interest payout and the player has been inactive for a total of `7 minutes` (so < 10), the condition 
```JAVA
        int bankInterestRecentActive = BuiltinModules.BANK.getConfiguration().getBankInterestRecentActive();
        if (checkOnlineOwner && bankInterestRecentActive > 0 && !owner.isOnline() &&
                currentTime - owner.getLastTimeStatus() > bankInterestRecentActive) {
            Log.debugResult(Debug.GIVE_BANK_INTEREST, "Return Cooldown", owner.getName());
            return false;
        }
```
is not met (despite `checkOnlineOwner` being set to `true`), and interest is granted, but based on a balance of 1 
```JAVA
        int bankInterestPercentage = BuiltinModules.BANK.getConfiguration().getBankInterestPercentage();

        BigDecimal balance = islandBank.getBalance().max(BigDecimal.ONE);
        BigDecimal balanceToGive = balance.multiply(new BigDecimal(bankInterestPercentage / 100D));
```
(because the actual balance hasn't loaded yet). Transactions also haven't loaded yet, so a new transaction with the first ID is created, once the existing transactions load, this new one will overwrite the old one.