### PR TITLE
Fix placeholder replacement key in SettingsContainer

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -401,7 +401,7 @@ public class SettingsContainer {
         if (config.isConfigurationSection("default-placeholders")) {
             for (String placeholderName : config.getConfigurationSection("default-placeholders").getKeys(false)) {
                 String placeholder = placeholderName.replace("superior_", "").toLowerCase(Locale.ENGLISH);
-                String replacement = config.getString("default-placeholders." + placeholder);
+                String replacement = config.getString("default-placeholders." + placeholderName);
                 defaultPlaceholders.put(placeholder, replacement);
             }
         }


### PR DESCRIPTION
Hello, if we use old format file it will not use correct name of placeholder and it will not replace them to default values.