### PR TITLE
Fixed couting newly placed spawners from RoseStacker

### DIFF
--- a/Hooks/RoseStacker/src/main/java/com/bgsoftware/superiorskyblock/external/spawners/SpawnersProvider_RoseStacker.java
+++ b/Hooks/RoseStacker/src/main/java/com/bgsoftware/superiorskyblock/external/spawners/SpawnersProvider_RoseStacker.java
@@ -69,12 +69,11 @@ public class SpawnersProvider_RoseStacker implements SpawnersProvider_AutoDetect
 
                 int increaseAmount = e.getStack().getStackSize() + e.getIncreaseAmount() > e.getStack().getStackSettings().getMaxStackSize() ?
                         e.getStack().getStackSettings().getMaxStackSize() - e.getStack().getStackSize() : e.getIncreaseAmount();
-                int newBlocksCount = e.isNew() ? Math.max(1, increaseAmount - 1) : increaseAmount;
 
-                if (island.hasReachedBlockLimit(blockKey, newBlocksCount)) {
+                if (island.hasReachedBlockLimit(blockKey, increaseAmount)) {
                     e.setCancelled(true);
                 } else {
-                    island.handleBlockPlace(blockKey, newBlocksCount);
+                    island.handleBlockPlace(blockKey, increaseAmount);
                 }
             }
         }

--- a/Hooks/RoseStacker1_5/src/main/java/com/bgsoftware/superiorskyblock/external/spawners/SpawnersProvider_RoseStacker1_5.java
+++ b/Hooks/RoseStacker1_5/src/main/java/com/bgsoftware/superiorskyblock/external/spawners/SpawnersProvider_RoseStacker1_5.java
@@ -68,12 +68,11 @@ public class SpawnersProvider_RoseStacker1_5 implements SpawnersProvider_AutoDet
 
                 int increaseAmount = e.getStack().getStackSize() + e.getIncreaseAmount() > e.getStack().getStackSettings().getMaxStackSize() ?
                         e.getStack().getStackSettings().getMaxStackSize() - e.getStack().getStackSize() : e.getIncreaseAmount();
-                int newBlocksCount = e.isNew() ? Math.max(1, increaseAmount - 1) : increaseAmount;
 
-                if (island.hasReachedBlockLimit(blockKey, newBlocksCount)) {
+                if (island.hasReachedBlockLimit(blockKey, increaseAmount)) {
                     e.setCancelled(true);
                 } else {
-                    island.handleBlockPlace(blockKey, newBlocksCount);
+                    island.handleBlockPlace(blockKey, increaseAmount);
                 }
             }
         }


### PR DESCRIPTION
Fixes #3024

Since we disable "listenToSpawnerChanges" in ProvidersManagerImpl when the SpawnersProvider is RoseStacker, we cannot subtract one spawner assuming it will be detected by the BlockPlaceEvent.