### PR TITLE
Fixed protection for removing leash knots from fences

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/listener/ProtectionListener.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/listener/ProtectionListener.java
@@ -70,6 +70,8 @@ public class ProtectionListener extends AbstractGameEventListener {
     private static final Material DECORATED_POT = EnumHelper.getEnum(Material.class, "DECORATED_POT");
     @Nullable
     private static final Material TARGET = EnumHelper.getEnum(Material.class, "TARGET");
+    @Nullable
+    private static final EntityType LEASH_KNOT = EnumHelper.getEnum(EntityType.class, "LEASH_KNOT");
 
     private final LazyReference<RegionManagerService> protectionManager = new LazyReference<RegionManagerService>() {
         @Override
@@ -243,12 +245,21 @@ public class ProtectionListener extends AbstractGameEventListener {
     }
 
     private boolean handleEntityInteract(GameEvent<GameEventArgs.PlayerInteractEvent> e) {
-        if (e.getArgs().clickedEntity == null)
+        Entity entity = e.getArgs().clickedEntity;
+
+        if (entity == null) {
             return false;
+        }
 
         SuperiorPlayer superiorPlayer = plugin.getPlayers().getSuperiorPlayer(e.getArgs().player);
-        InteractionResult interactionResult = this.protectionManager.get().handleEntityInteract(superiorPlayer,
-                e.getArgs().clickedEntity, e.getArgs().usedItem);
+
+        InteractionResult interactionResult;
+        if (entity.getType() == LEASH_KNOT) {
+            interactionResult = this.protectionManager.get().handleEntityLeash(superiorPlayer, entity);
+        } else {
+            interactionResult = this.protectionManager.get().handleEntityInteract(superiorPlayer, entity, e.getArgs().usedItem);
+        }
+
         if (ProtectionHelper.shouldPreventInteraction(interactionResult, superiorPlayer, true)) {
             e.setCancelled();
             return true;


### PR DESCRIPTION
Fixes #2894 

Some versions handle this correctly without the change, while others don't; this is because, in newer versions, clicking the leash knot doesn't unleash the mob, instead, the player ends up holding it on the leash. Curiously, though, on version 1.21.7 it suddenly works correctly without my changes (even though the person who reported the issue tested it on that version, and I had tested it there too), whereas on 26.2 it doesn't work, which is why this change needs to be merged.