### PR TITLE
improv. rename TAMEABLE to TAMED and update entity category handling

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -747,7 +747,26 @@ public class SettingsContainer {
             removeInvalidEntityKeys = true;
         }
 
-        YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+        CommentedConfiguration cfg = CommentedConfiguration.loadConfiguration(file);
+
+        ConfigurationSection tameable = cfg.getConfigurationSection("TAMEABLE");
+        if (tameable != null) {
+            if (!cfg.contains("TAMED"))
+                cfg.createSection("TAMED");
+
+            for (Map.Entry<String, Object> entry : tameable.getValues(true).entrySet()) {
+                String path = "TAMED." + entry.getKey();
+                if (!(entry.getValue() instanceof ConfigurationSection) && !cfg.contains(path))
+                    cfg.set(path, entry.getValue());
+            }
+
+            cfg.set("TAMEABLE", null);
+            try {
+                cfg.save(file);
+            } catch (IOException error) {
+                Log.errorFromFile(error, file.getName(), "Failed to save converted entity categories:");
+            }
+        }
 
         if (removeInvalidEntityKeys) {
             EntityCategoriesSection.removeInvalidEntityKeys(cfg, file);

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/SettingsContainer.java
@@ -749,18 +749,17 @@ public class SettingsContainer {
 
         CommentedConfiguration cfg = CommentedConfiguration.loadConfiguration(file);
 
-        ConfigurationSection tameable = cfg.getConfigurationSection("TAMEABLE");
-        if (tameable != null) {
-            if (!cfg.contains("TAMED"))
-                cfg.createSection("TAMED");
-
-            for (Map.Entry<String, Object> entry : tameable.getValues(true).entrySet()) {
-                String path = "TAMED." + entry.getKey();
-                if (!(entry.getValue() instanceof ConfigurationSection) && !cfg.contains(path))
-                    cfg.set(path, entry.getValue());
-            }
-
-            cfg.set("TAMEABLE", null);
+        List<String> tameableNames = cfg.getKeys(false).stream()
+                .filter("TAMEABLE"::equalsIgnoreCase).collect(Collectors.toList());
+        ConfigurationSection tameable = tameableNames.size() != 1 ? null : cfg.getConfigurationSection(tameableNames.get(0));
+        if (tameable != null && "TAMED_ANIMAL_DAMAGE".equalsIgnoreCase(tameable.getString("actions.DAMAGE")) &&
+                cfg.getKeys(false).stream().noneMatch("TAMED"::equalsIgnoreCase)) {
+            cfg.set("TAMED.actions.DAMAGE", tameable.getString("actions.DAMAGE"));
+            tameable.set("actions.DAMAGE", null);
+            if (tameable.getConfigurationSection("actions").getKeys(false).isEmpty())
+                tameable.set("actions", null);
+            if (tameable.getKeys(false).isEmpty())
+                cfg.set(tameable.getName(), null);
             try {
                 cfg.save(file);
             } catch (IOException error) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/EntityCategoriesSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/EntityCategoriesSection.java
@@ -127,7 +127,7 @@ public class EntityCategoriesSection implements SettingsManager.EntityCategories
         for (EntityCategory entityCategory : entityCategories) {
             BuiltinEntityCategory builtinCategory = EnumHelper.getEnum(BuiltinEntityCategory.class,
                     entityCategory.getName().toUpperCase(Locale.ENGLISH));
-            if (builtinCategory != null && builtinCategory.requiresEntityState())
+            if (builtinCategory != null && builtinCategory.isExcludedFromTypeLookup())
                 continue;
 
             for (Key key : entityCategory.getEntities()) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/config/section/EntityCategoriesSection.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/config/section/EntityCategoriesSection.java
@@ -53,7 +53,7 @@ public class EntityCategoriesSection implements SettingsManager.EntityCategories
     public static void removeInvalidEntityKeys(YamlConfiguration cfg, File file) {
         boolean removed = false;
         for (String categoryName : cfg.getKeys(false)) {
-            if (EnumHelper.getEnum(BuiltinEntityCategory.class, categoryName) == null) {
+            if (EnumHelper.getEnum(BuiltinEntityCategory.class, categoryName.toUpperCase(Locale.ENGLISH)) == null) {
                 List<String> entities = cfg.getStringList(categoryName + ".entities");
                 Iterator<String> iterator = entities.iterator();
                 while (iterator.hasNext()) {
@@ -86,7 +86,7 @@ public class EntityCategoriesSection implements SettingsManager.EntityCategories
         for (String categoryName : cfg.getKeys(false)) {
             String key = categoryName.toLowerCase(Locale.ENGLISH);
 
-            if (entityCategories.containsKey(categoryName)) {
+            if (entityCategories.containsKey(key)) {
                 Log.warnFromFile("entity-categories.yml", "Duplicate entity category ", categoryName, " - skipping...");
                 continue;
             }
@@ -111,8 +111,9 @@ public class EntityCategoriesSection implements SettingsManager.EntityCategories
 
         // Add rest of built-in entity categories
         for (BuiltinEntityCategory builtinEntityCategory : BuiltinEntityCategory.values()) {
-            if (!entityCategories.containsKey(builtinEntityCategory.name())) {
-                entityCategories.put(builtinEntityCategory.name(), new EntityCategoryImpl(builtinEntityCategory.name(),
+            String key = builtinEntityCategory.name().toLowerCase(Locale.ENGLISH);
+            if (!entityCategories.containsKey(key)) {
+                entityCategories.put(key, new EntityCategoryImpl(builtinEntityCategory.name(),
                         builtinEntityCategory.getEntities(), null, null,
                         null, null, null));
             }
@@ -124,6 +125,11 @@ public class EntityCategoriesSection implements SettingsManager.EntityCategories
     private static KeyMap<List<EntityCategory>> convertEntityToCategoryInternal(Collection<EntityCategory> entityCategories) {
         KeyMap<List<EntityCategory>> categories = KeyMaps.createHashMap(KeyIndicator.ENTITY_TYPE);
         for (EntityCategory entityCategory : entityCategories) {
+            BuiltinEntityCategory builtinCategory = EnumHelper.getEnum(BuiltinEntityCategory.class,
+                    entityCategory.getName().toUpperCase(Locale.ENGLISH));
+            if (builtinCategory != null && builtinCategory.requiresEntityState())
+                continue;
+
             for (Key key : entityCategory.getEntities()) {
                 categories.computeIfAbsent(key, k -> new LinkedList<>()).add(entityCategory);
             }

--- a/src/main/java/com/bgsoftware/superiorskyblock/listener/ProtectionListener.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/listener/ProtectionListener.java
@@ -590,7 +590,7 @@ public class ProtectionListener extends AbstractGameEventListener {
                     hitBlock = null;
                     location = hitEntity.getLocation(wrapper.getHandle());
 
-                    List<EntityCategory> entityCategories = plugin.getSettings().getEntityCategoriesMap().getCategories(Keys.of(entity));
+                    List<EntityCategory> entityCategories = BukkitEntities.getCategories(hitEntity);
                     interactionResult = InteractionResult.SUCCESS;
 
                     for (EntityCategory entityCategory : entityCategories) {

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/BukkitEntities.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/BukkitEntities.java
@@ -2,6 +2,7 @@ package com.bgsoftware.superiorskyblock.world;
 
 import com.bgsoftware.common.annotations.Nullable;
 import com.bgsoftware.superiorskyblock.SuperiorSkyblockPlugin;
+import com.bgsoftware.superiorskyblock.api.config.SettingsManager;
 import com.bgsoftware.superiorskyblock.api.entity.EntityCategory;
 import com.bgsoftware.superiorskyblock.api.hooks.EntitiesProvider;
 import com.bgsoftware.superiorskyblock.api.key.Key;
@@ -150,7 +151,7 @@ public class BukkitEntities {
         return false;
     }
 
-    public static boolean isTameable(Entity entity) {
+    public static boolean isTamed(Entity entity) {
         return entity instanceof Tameable && ((Tameable) entity).isTamed();
     }
 
@@ -163,12 +164,18 @@ public class BukkitEntities {
     }
 
     public static List<EntityCategory> getCategories(Entity entity) {
-        List<EntityCategory> categories = plugin.getSettings().getEntityCategoriesMap().getCategories(Keys.of(entity));
-        if (isTameable(entity)) {
-            categories = new LinkedList<>(categories);
-            categories.add(BuiltinEntityCategory.TAMEABLE.getEntityCategory());
-        }
-        return categories;
+        SettingsManager.EntityCategories categorySettings = plugin.getSettings().getEntityCategoriesMap();
+        List<EntityCategory> categories = categorySettings.getCategories(Keys.of(entity));
+        if (!isTamed(entity))
+            return categories;
+
+        EntityCategory tamedCategory = categorySettings.getCategoryByName(BuiltinEntityCategory.TAMED.name());
+        if (tamedCategory == null)
+            return categories;
+
+        List<EntityCategory> applicableCategories = new LinkedList<>(categories);
+        applicableCategories.add(tamedCategory);
+        return applicableCategories;
     }
 
 }

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/BukkitEntities.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/BukkitEntities.java
@@ -169,12 +169,9 @@ public class BukkitEntities {
         if (!isTamed(entity))
             return categories;
 
-        EntityCategory tamedCategory = categorySettings.getCategoryByName(BuiltinEntityCategory.TAMED.name());
-        if (tamedCategory == null)
-            return categories;
-
         List<EntityCategory> applicableCategories = new LinkedList<>(categories);
-        applicableCategories.add(tamedCategory);
+        applicableCategories.remove(categorySettings.getCategoryByName(BuiltinEntityCategory.TAMEABLE.name()));
+        applicableCategories.add(categorySettings.getCategoryByName(BuiltinEntityCategory.TAMED.name()));
         return applicableCategories;
     }
 

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/entity/BuiltinEntityCategory.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/entity/BuiltinEntityCategory.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 public enum BuiltinEntityCategory {
 
-    TAMEABLE {
+    TAMED(true) {
         @Override
         protected boolean isEntityListedInternal(Class<? extends Entity> entityClass) {
             return Tameable.class.isAssignableFrom(entityClass);
@@ -76,7 +76,20 @@ public enum BuiltinEntityCategory {
             return getEntitiesInternal();
         }
     };
+    private final boolean entityStateRequired;
     private WeakReference<EntityCategory> entityCategoryReference;
+
+    BuiltinEntityCategory() {
+        this(false);
+    }
+
+    BuiltinEntityCategory(boolean entityStateRequired) {
+        this.entityStateRequired = entityStateRequired;
+    }
+
+    public boolean requiresEntityState() {
+        return entityStateRequired;
+    }
 
     public KeySet getEntities() {
         return entities.get();

--- a/src/main/java/com/bgsoftware/superiorskyblock/world/entity/BuiltinEntityCategory.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/world/entity/BuiltinEntityCategory.java
@@ -24,10 +24,16 @@ import java.util.Objects;
 
 public enum BuiltinEntityCategory {
 
-    TAMED(true) {
+    TAMEABLE {
         @Override
         protected boolean isEntityListedInternal(Class<? extends Entity> entityClass) {
             return Tameable.class.isAssignableFrom(entityClass);
+        }
+    },
+    TAMED(true) {
+        @Override
+        protected boolean isEntityListedInternal(Class<? extends Entity> entityClass) {
+            return TAMEABLE.isEntityListedInternal(entityClass);
         }
     },
     VEHICLE {
@@ -76,19 +82,19 @@ public enum BuiltinEntityCategory {
             return getEntitiesInternal();
         }
     };
-    private final boolean entityStateRequired;
+    private final boolean excludedFromTypeLookup;
     private WeakReference<EntityCategory> entityCategoryReference;
 
     BuiltinEntityCategory() {
         this(false);
     }
 
-    BuiltinEntityCategory(boolean entityStateRequired) {
-        this.entityStateRequired = entityStateRequired;
+    BuiltinEntityCategory(boolean excludedFromTypeLookup) {
+        this.excludedFromTypeLookup = excludedFromTypeLookup;
     }
 
-    public boolean requiresEntityState() {
-        return entityStateRequired;
+    public boolean isExcludedFromTypeLookup() {
+        return excludedFromTypeLookup;
     }
 
     public KeySet getEntities() {

--- a/src/main/resources/entity-categories.yml
+++ b/src/main/resources/entity-categories.yml
@@ -22,7 +22,7 @@
 #     # The island flag required so the entities can spawn vanilla
 #     NATURAL_SPAWN: <ISLAND_FLAG>
 # You can create as many custom categories as you want.
-# There are custom groups used for detecting animals, monsters and tamed entities.
+# There are custom groups used for detecting animals, monsters, tameable species and tamed entities.
 # These groups do not have `entities` and the entities are added automatically depending on your Minecraft version.
 
 # Custom interact groups
@@ -108,6 +108,11 @@ PAINTING:
     INTERACT: PAINTING
 
 # Custom built-in groups
+# TAMEABLE only includes untamed entities of tameable species.
+# TAMED only includes entities that are currently tamed.
+TAMEABLE:
+  actions: {}
+
 TAMED:
   actions:
     DAMAGE: TAMED_ANIMAL_DAMAGE

--- a/src/main/resources/entity-categories.yml
+++ b/src/main/resources/entity-categories.yml
@@ -22,7 +22,7 @@
 #     # The island flag required so the entities can spawn vanilla
 #     NATURAL_SPAWN: <ISLAND_FLAG>
 # You can create as many custom categories as you want.
-# There are custom groups used for detecting animals, monsters and tameable entities.
+# There are custom groups used for detecting animals, monsters and tamed entities.
 # These groups do not have `entities` and the entities are added automatically depending on your Minecraft version.
 
 # Custom interact groups
@@ -108,7 +108,7 @@ PAINTING:
     INTERACT: PAINTING
 
 # Custom built-in groups
-TAMEABLE:
+TAMED:
   actions:
     DAMAGE: TAMED_ANIMAL_DAMAGE
 


### PR DESCRIPTION
Hello,

Untamed animals, including llamas wolf etc, were incorrectly subject to TAMED_ANIMAL_DAMAGE because the TAMEABLE category matched every animal capable of being tamed, regardless of its actual state.

This PR applies that category only to animals that are already tamed and renames it to TAMED to clarify its meaning. Existing TAMEABLE configuration sections are automatically migrated, preserving their settings.

